### PR TITLE
fix : README.md links and references in timpani-o and timpani-n [#12]

### DIFF
--- a/sample-apps/README.md
+++ b/sample-apps/README.md
@@ -180,7 +180,7 @@ docker build -t centos_latest:sample_apps_v3 -f ./Dockerfile.centos ./
 
 ### Docker Run
 ```bash
-# Run basic workload (scheduling parameters managed by piccolo and timpani-o/timpani-n)
+# Run basic workload (scheduling parameters managed by pullpiri and timpani-o/timpani-n)
 docker run -it --rm -d \
     --ulimit rtprio=99 \
     --cap-add=sys_nice \

--- a/timpani-n/README.md
+++ b/timpani-n/README.md
@@ -1,4 +1,4 @@
-# Time Trigger
+# Timpani N
 
 
 

--- a/timpani-o/.github/copilot-instructions.md
+++ b/timpani-o/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Project Overview
 
 This `Timpani-O` project is a C++ application that interacts with a time-triggered scheduling system for real-time tasks.
-It includes a gRPC server that allows `Piccolo`, a workload orchestrator, to add new scheduling tables, and a gRPC client to notify `Piccolo` of deadline miss faults.
+It includes a gRPC server that allows `Pullpiri`, a workload orchestrator, to add new scheduling tables, and a gRPC client to notify `Pullpiri` of deadline miss faults.
 Additionally, it provides a D-Bus peer-to-peer server that offers the following time-triggered scheduling features for `Timpani-N` (also known as the Timpani node manager):
 
   - Send scheduling tables to `Timpani-N`
@@ -18,7 +18,7 @@ Additionally, it provides a D-Bus peer-to-peer server that offers the following 
 ## Libraries and Dependencies
 
 - CMake: For building the project.
-- gRPC: For communication between `Timpani-O` and `Piccolo`.
+- gRPC: For communication between `Timpani-O` and `Pullpiri`.
 - Protocol Buffers: For serializing structured data.
 
 ## Coding Style

--- a/timpani-o/README.md
+++ b/timpani-o/README.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Refer to [This README.md](https://github.com/MCO-PICCOLO/TIMPANI/blob/main/timpani-n/README.md) for the full description of the project.
+Refer to [TIMPANI-N's README.md](https://github.com/MCO-PICCOLO/TIMPANI/blob/main/timpani-n/README.md) for the full description of the project.
 
 ## Prerequisites
 

--- a/timpani-o/proto/schedinfo.proto
+++ b/timpani-o/proto/schedinfo.proto
@@ -5,14 +5,14 @@ package schedinfo.v1;
 // SchedInfoService in Timpani-O
 service SchedInfoService {
   // Add a new SchedInfo
-  // From Piccolo to Timpani-O
+  // From Pullpiri to Timpani-O
   rpc AddSchedInfo (SchedInfo) returns (Response) {}
 }
 
-// FaultService in Piccolo
+// FaultService in Pullpiri
 service FaultService {
   // Notify a fault
-  // From Timpani-O to Piccolo
+  // From Timpani-O to Pullpiri
   rpc NotifyFault (FaultInfo) returns (Response) {}
 }
 

--- a/timpani-o/src/fault_client.cpp
+++ b/timpani-o/src/fault_client.cpp
@@ -22,7 +22,7 @@ bool FaultServiceClient::Initialize(const std::string& server_address)
     }
 
     if (!CreateChannel(server_address)) {
-        TLOG_ERROR("Failed to create gRPC channel to Piccolo");
+        TLOG_ERROR("Failed to create gRPC channel to Pullpiri");
         return false;
     }
 
@@ -54,7 +54,7 @@ bool FaultServiceClient::NotifyFault(const std::string &workload_id,
     Response reply;
     ClientContext context;
 
-    TLOG_INFO("Notifying Piccolo - Workload: ", workload_id,
+    TLOG_INFO("Notifying Pullpiri - Workload: ", workload_id,
               ", Node: ", node_id, ", Task: ", task_name,
               ", Fault Type: ", FaultTypeToStr(fault_type));
 
@@ -67,7 +67,7 @@ bool FaultServiceClient::NotifyFault(const std::string &workload_id,
     }
 
     if (reply.status() != 0) {
-        TLOG_ERROR("NotifyFault: Piccolo returned error: ", reply.status());
+        TLOG_ERROR("NotifyFault: Pullpiri returned error: ", reply.status());
         return false;
     }
 

--- a/timpani-o/src/fault_client.h
+++ b/timpani-o/src/fault_client.h
@@ -16,10 +16,10 @@ using schedinfo::v1::FaultType;
 using schedinfo::v1::Response;
 
 /**
- * @brief Singleton gRPC client for communicating with Piccolo's FaultService
+ * @brief Singleton gRPC client for communicating with Pullpiri's FaultService
  *
  * This class implements the Singleton design pattern and manages a persistent
- * gRPC connection to Piccolo for fault notifications.
+ * gRPC connection to Pullpiri for fault notifications.
  *
  * Usage example:
  *   FaultServiceClient& client = FaultServiceClient::GetInstance();
@@ -32,7 +32,7 @@ class FaultServiceClient
   public:
     static FaultServiceClient& GetInstance();
 
-    // Initialize the gRPC connection to Piccolo
+    // Initialize the gRPC connection to Pullpiri
     bool Initialize(const std::string& server_address);
 
     // Check if the client is properly initialized

--- a/timpani-o/src/schedinfo_service.h
+++ b/timpani-o/src/schedinfo_service.h
@@ -28,7 +28,7 @@ using SchedInfoMap = std::map<std::string, NodeSchedInfoMap>;
 /**
 * @brief Implementation of the SchedInfoService gRPC service
 *
-* This service handles scheduling information deliveries from Piccolo to Timpani-O.
+* This service handles scheduling information deliveries from Pullpiri to Timpani-O.
 * It processes SchedInfo messages and returns a Response indicating success or failure.
 */
 class SchedInfoServiceImpl final : public SchedInfoService::Service


### PR DESCRIPTION
## 📝 PR Description
This PR updates the README.md files in `timpani-o` and `timpani-n`:
- Changes the "This README.md" link in `timpani-o/README.md` to point to `timpani-n/README.md`.
- Updates the link text to "TIMPANI-N's README.md" for clarity.
- Verifies and corrects other internal and external links as needed.
- Rename of Piccolo to Pullpiri 
- This README -> TIMPANI-N's README.md

## 🔗 Related Issue
Closes #12 
Closes #13 

## 🧪 Test Method
- Open the updated README.md files in GitHub and verify that all links work as intended.
- Confirm that the link text is clear and unambiguous.


## ✅ Checklist
- [x] Code conventions are followed
- [x] Documentation is updated
- [ ] Tests are added/modified (N/A for documentation)