### PR TITLE
feat(rust): gRPC wiring, fault client, test-tools, coverage tests

### DIFF
--- a/timpani_rust/Cargo.lock
+++ b/timpani_rust/Cargo.lock
@@ -1053,6 +1053,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-tools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_yaml",
+ "timpani-o",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/timpani_rust/Cargo.toml
+++ b/timpani_rust/Cargo.toml
@@ -4,5 +4,6 @@
 [workspace]
 members = [
     "timpani-o",
+    "test-tools",
 ]
 resolver = "2"

--- a/timpani_rust/test-tools/Cargo.toml
+++ b/timpani_rust/test-tools/Cargo.toml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "test-tools"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Manual test simulators for Timpani-O — NOT for production"
+
+# ── Binaries ──────────────────────────────────────────────────────────────────
+
+[[bin]]
+# Simulates Piccolo:
+#   • Serves FaultService on --fault-port (receives deadline-miss notifications)
+#   • Reads a workload YAML and sends AddSchedInfo to Timpani-O
+name = "piccolo-sim"
+path = "src/bin/piccolo_sim.rs"
+
+[[bin]]
+# Simulates one or more Timpani-N nodes concurrently:
+#   • GetSchedInfo → SyncTimer → (optional) ReportDMiss
+name = "node-sim"
+path = "src/bin/node_sim.rs"
+
+# ── Dependencies ──────────────────────────────────────────────────────────────
+
+[dependencies]
+# Re-use all proto types and service stubs from the main crate.
+# No need to recompile the protos — they are already compiled by timpani-o.
+timpani-o = { path = "../timpani-o" }
+
+tokio  = { version = "1", features = ["full"] }
+tonic  = "0.12"
+
+serde      = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+
+tracing            = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+clap   = { version = "4", features = ["derive"] }
+anyhow = "1"

--- a/timpani_rust/test-tools/Cargo.toml
+++ b/timpani_rust/test-tools/Cargo.toml
@@ -11,11 +11,11 @@ description = "Manual test simulators for Timpani-O — NOT for production"
 # ── Binaries ──────────────────────────────────────────────────────────────────
 
 [[bin]]
-# Simulates Piccolo:
+# Simulates Pullpiri:
 #   • Serves FaultService on --fault-port (receives deadline-miss notifications)
 #   • Reads a workload YAML and sends AddSchedInfo to Timpani-O
-name = "piccolo-sim"
-path = "src/bin/piccolo_sim.rs"
+name = "pullpiri-sim"
+path = "src/bin/pullpiri_sim.rs"
 
 [[bin]]
 # Simulates one or more Timpani-N nodes concurrently:

--- a/timpani_rust/test-tools/src/bin/node_sim.rs
+++ b/timpani_rust/test-tools/src/bin/node_sim.rs
@@ -1,0 +1,283 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! node-sim — manual test simulator for multiple Timpani-N nodes.
+//!
+//! Spawns one Tokio task per node ID and exercises the full node protocol:
+//!
+//!   1. `GetSchedInfo(node_id)` — fetches and prints the assigned schedule
+//!   2. `SyncTimer(node_id)`    — blocks until all nodes have called this,
+//!      printing the shared start time on ACK
+//!   3. `ReportDMiss(node_id, task)` — optional, triggered by `--dmiss`
+//!
+//! # Usage
+//! ```text
+//! # After piccolo-sim has sent AddSchedInfo:
+//! cargo run --bin node-sim -- \
+//!     --nodes node01,node02,node03 \
+//!     --dmiss node01:task_safety \
+//!     --dmiss-delay-ms 2000
+//! ```
+//!
+//! This concurrently fires the sync barrier so Timpani-O dispatches start_time
+//! to all three nodes at once.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use tracing::{error, info, warn};
+
+use timpani_o::proto::schedinfo_v1::{
+    node_service_client::NodeServiceClient, DeadlineMissInfo, NodeSchedRequest, SyncRequest,
+};
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "node-sim",
+    about = "Timpani-N node simulator: GetSchedInfo → SyncTimer → ReportDMiss"
+)]
+struct Cli {
+    /// Host where Timpani-O's node-facing service is listening.
+    #[arg(long, default_value = "localhost")]
+    node_host: String,
+
+    /// Port for Timpani-O's node-facing service.
+    #[arg(long, default_value_t = 50054)]
+    node_port: u16,
+
+    /// Comma-separated list of node IDs to simulate concurrently.
+    /// All listed nodes will call SyncTimer at the same time to fire the
+    /// barrier.  This list must match the nodes that received tasks from
+    /// AddSchedInfo, otherwise the barrier will never release.
+    #[arg(long, default_value = "node01,node02,node03")]
+    nodes: String,
+
+    /// Send a deadline-miss report from one node, given as "node_id:task_name".
+    /// Example: --dmiss node01:task_safety
+    #[arg(long)]
+    dmiss: Option<String>,
+
+    /// Milliseconds to wait after SyncTimer ACK before sending ReportDMiss.
+    /// Simulates the task running for a while before missing its deadline.
+    #[arg(long, default_value_t = 2000)]
+    dmiss_delay_ms: u64,
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    let node_ids: Vec<String> = cli
+        .nodes
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if node_ids.is_empty() {
+        anyhow::bail!("--nodes must contain at least one node ID");
+    }
+
+    let addr = format!("http://{}:{}", cli.node_host, cli.node_port);
+
+    // Parse --dmiss "node_id:task_name"
+    let dmiss_target: Option<(String, String)> = match &cli.dmiss {
+        None => None,
+        Some(s) => {
+            let mut parts = s.splitn(2, ':');
+            match (parts.next(), parts.next()) {
+                (Some(n), Some(t)) if !n.is_empty() && !t.is_empty() => {
+                    Some((n.to_string(), t.to_string()))
+                }
+                _ => {
+                    anyhow::bail!("--dmiss format must be 'node_id:task_name', got: '{s}'");
+                }
+            }
+        }
+    };
+
+    info!("Simulating {} node(s) against {addr}", node_ids.len());
+    info!("Nodes: {:?}", node_ids);
+    if let Some((n, t)) = &dmiss_target {
+        info!(
+            "After barrier: node '{}' will report deadline miss on task '{}' \
+             after {} ms",
+            n, t, cli.dmiss_delay_ms
+        );
+    }
+
+    // ── Spawn one Tokio task per node concurrently ────────────────────────────
+    let mut handles = Vec::with_capacity(node_ids.len());
+
+    for node_id in &node_ids {
+        let node_id = node_id.clone();
+        let addr = addr.clone();
+        let dmiss = dmiss_target.clone();
+        let dmiss_delay = cli.dmiss_delay_ms;
+
+        let handle = tokio::spawn(async move {
+            if let Err(e) = simulate_node(&node_id, &addr, dmiss, dmiss_delay).await {
+                error!("[{node_id}] simulation error: {e}");
+            }
+        });
+        handles.push(handle);
+    }
+
+    for h in handles {
+        h.await.ok();
+    }
+
+    info!("All node simulations complete.");
+    Ok(())
+}
+
+// ── per-node protocol sequence ────────────────────────────────────────────────
+
+async fn simulate_node(
+    node_id: &str,
+    addr: &str,
+    dmiss: Option<(String, String)>,
+    dmiss_delay_ms: u64,
+) -> Result<()> {
+    let mut client = NodeServiceClient::connect(addr.to_string())
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "[{node_id}] cannot connect to NodeService at {addr}: {e}\n\
+                 → Is Timpani-O running and has AddSchedInfo been sent?",
+                node_id = node_id,
+                addr = addr
+            )
+        })?;
+
+    info!("[{node_id}] connected to NodeService at {addr}");
+
+    // ── 1. GetSchedInfo ───────────────────────────────────────────────────────
+    info!("[{node_id}] → GetSchedInfo");
+
+    let resp = client
+        .get_sched_info(NodeSchedRequest {
+            node_id: node_id.to_string(),
+        })
+        .await
+        .map_err(|s| anyhow::anyhow!("[{node_id}] GetSchedInfo failed: {s}", node_id = node_id))?
+        .into_inner();
+
+    info!(
+        "[{node_id}] ← GetSchedInfo: workload='{}' hyperperiod={}µs tasks={}",
+        resp.workload_id,
+        resp.hyperperiod_us,
+        resp.tasks.len()
+    );
+
+    for t in &resp.tasks {
+        let cpu = if t.cpu_affinity != 0 {
+            t.cpu_affinity.trailing_zeros()
+        } else {
+            u32::MAX // "any"
+        };
+        let policy = match t.sched_policy {
+            0 => "NORMAL",
+            1 => "FIFO",
+            2 => "RR",
+            _ => "?",
+        };
+        let cpu_str = if cpu == u32::MAX {
+            "any".to_string()
+        } else {
+            format!("CPU{cpu}")
+        };
+        info!(
+            "[{node_id}]    ▸ name={:<20} {:<6} prio={:>3}  policy={:<6}  \
+             period={:>7}µs  runtime={:>6}µs  deadline={:>7}µs  max_dmiss={}",
+            t.name,
+            cpu_str,
+            t.sched_priority,
+            policy,
+            t.period_us,
+            t.runtime_us,
+            t.deadline_us,
+            t.max_dmiss
+        );
+    }
+
+    if resp.tasks.is_empty() {
+        warn!(
+            "[{node_id}] no tasks assigned to this node — \
+             skipping SyncTimer (it would block the barrier)"
+        );
+        return Ok(());
+    }
+
+    // ── 2. SyncTimer — blocks until ALL nodes have called it ─────────────────
+    info!("[{node_id}] → SyncTimer  (waiting for all nodes to synchronise…)");
+
+    let sync = client
+        .sync_timer(SyncRequest {
+            node_id: node_id.to_string(),
+        })
+        .await
+        .map_err(|s| anyhow::anyhow!("[{node_id}] SyncTimer failed: {s}", node_id = node_id))?
+        .into_inner();
+
+    if sync.ack {
+        info!(
+            "[{node_id}] ✅  Barrier released — start at {}.{:09}s (CLOCK_REALTIME)",
+            sync.start_time_sec, sync.start_time_nsec
+        );
+    } else {
+        warn!("[{node_id}] ⚠️  SyncTimer returned ack=false — aborting");
+        return Ok(());
+    }
+
+    // ── 3. Optional deadline miss report ─────────────────────────────────────
+    if let Some((dmiss_node, dmiss_task)) = &dmiss {
+        if dmiss_node.as_str() == node_id {
+            info!(
+                "[{node_id}] ⏱  Simulating task run — waiting {dmiss_delay_ms} ms \
+                 before reporting deadline miss on '{dmiss_task}'"
+            );
+            tokio::time::sleep(Duration::from_millis(dmiss_delay_ms)).await;
+
+            info!("[{node_id}] → ReportDMiss  task='{dmiss_task}'");
+            let dr = client
+                .report_d_miss(DeadlineMissInfo {
+                    node_id: node_id.to_string(),
+                    task_name: dmiss_task.clone(),
+                })
+                .await
+                .map_err(|s| {
+                    anyhow::anyhow!("[{node_id}] ReportDMiss failed: {s}", node_id = node_id)
+                })?
+                .into_inner();
+
+            if dr.status == 0 {
+                info!(
+                    "[{node_id}] ✅  ReportDMiss acknowledged — \
+                       Timpani-O will forward to Piccolo's FaultService"
+                );
+            } else {
+                warn!(
+                    "[{node_id}] ⚠️  ReportDMiss status={} msg='{}'",
+                    dr.status, dr.error_message
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/timpani_rust/test-tools/src/bin/node_sim.rs
+++ b/timpani_rust/test-tools/src/bin/node_sim.rs
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
 //!
 //! # Usage
 //! ```text
-//! # After piccolo-sim has sent AddSchedInfo:
+//! # After pullpiri-sim has sent AddSchedInfo:
 //! cargo run --bin node-sim -- \
 //!     --nodes node01,node02,node03 \
 //!     --dmiss node01:task_safety \
@@ -268,7 +268,7 @@ async fn simulate_node(
             if dr.status == 0 {
                 info!(
                     "[{node_id}] ✅  ReportDMiss acknowledged — \
-                       Timpani-O will forward to Piccolo's FaultService"
+                       Timpani-O will forward to Pullpiri's FaultService"
                 );
             } else {
                 warn!(

--- a/timpani_rust/test-tools/src/bin/piccolo_sim.rs
+++ b/timpani_rust/test-tools/src/bin/piccolo_sim.rs
@@ -1,0 +1,210 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! piccolo-sim — manual test simulator for Piccolo's two roles:
+//!
+//! **Role 1 — Client**: reads a workload YAML, sends `AddSchedInfo` to
+//! Timpani-O's upstream gRPC port.
+//!
+//! **Role 2 — Server**: serves `FaultService` so Timpani-O can forward
+//! deadline-miss notifications here.
+//!
+//! # Usage
+//! ```text
+//! # Terminal 1: start Timpani-O first
+//! cargo run --bin timpani-o -- --nodeconfig ../../timpani-o/examples/node_configurations.yaml
+//!
+//! # Terminal 2: start piccolo-sim
+//! cargo run --bin piccolo-sim -- --workload test-tools/workloads/example_workload.yaml
+//!
+//! # Terminal 3: start node-sim (fires the sync barrier, then sends a deadline miss)
+//! cargo run --bin node-sim -- --nodes node01,node02,node03 --dmiss node01:task_safety
+//! ```
+//!
+//! piccolo-sim will then print:
+//!   ✅  AddSchedInfo succeeded
+//!   🔔  FAULT: workload=test_workload node=node01 task=task_safety type=DMISS
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+use timpani_o::proto::schedinfo_v1::{
+    fault_service_server::{FaultService, FaultServiceServer},
+    sched_info_service_client::SchedInfoServiceClient,
+    FaultInfo, Response as ProtoResponse, SchedInfo,
+};
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "piccolo-sim",
+    about = "Piccolo simulator: sends AddSchedInfo and receives fault notifications"
+)]
+struct Cli {
+    /// Host where Timpani-O SchedInfoService is listening.
+    #[arg(long, default_value = "localhost")]
+    sinfo_host: String,
+
+    /// Port for Timpani-O's upstream SchedInfoService.
+    #[arg(long, default_value_t = 50052)]
+    sinfo_port: u16,
+
+    /// Port this simulator listens on for Timpani-O's fault notifications.
+    /// Must match --faultport used when starting timpani-o.
+    #[arg(long, default_value_t = 50053)]
+    fault_port: u16,
+
+    /// Path to the workload YAML file to send.
+    #[arg(long, short = 'w')]
+    workload: PathBuf,
+}
+
+// ── FaultService implementation ───────────────────────────────────────────────
+
+/// Receives `NotifyFault` calls from Timpani-O and logs them.
+struct PiccoloFaultService;
+
+#[tonic::async_trait]
+impl FaultService for PiccoloFaultService {
+    async fn notify_fault(
+        &self,
+        request: Request<FaultInfo>,
+    ) -> Result<Response<ProtoResponse>, Status> {
+        let info = request.into_inner();
+        let fault_type = match info.r#type {
+            0 => "UNKNOWN",
+            1 => "DMISS",
+            _ => "INVALID",
+        };
+        // Use eprintln directly so the notification stands out regardless of
+        // log level.
+        eprintln!(
+            "\n🔔  FAULT NOTIFICATION\n\
+             \tworkload  : {}\n\
+             \tnode      : {}\n\
+             \ttask      : {}\n\
+             \ttype      : {}\n",
+            info.workload_id, info.node_id, info.task_name, fault_type
+        );
+        info!(
+            workload = %info.workload_id,
+            node     = %info.node_id,
+            task     = %info.task_name,
+            fault    = %fault_type,
+            "FaultService: NotifyFault received"
+        );
+        Ok(Response::new(ProtoResponse { status: 0 }))
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    // ── Step 1: start the FaultService server ─────────────────────────────────
+    let fault_addr: std::net::SocketAddr = format!("0.0.0.0:{}", cli.fault_port).parse()?;
+
+    info!("Starting FaultService on {fault_addr}");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let fault_server = {
+        let mut rx = shutdown_rx.clone();
+        Server::builder()
+            .add_service(FaultServiceServer::new(PiccoloFaultService))
+            .serve_with_shutdown(fault_addr, async move {
+                while !*rx.borrow() {
+                    rx.changed().await.ok();
+                }
+            })
+    };
+    tokio::spawn(fault_server);
+
+    // Brief pause to let the fault server port become available.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    info!(
+        "FaultService ready — Timpani-O can now send fault notifications to :{}",
+        cli.fault_port
+    );
+
+    // ── Step 2: read workload YAML ────────────────────────────────────────────
+    info!("Reading workload from: {}", cli.workload.display());
+    let file = std::fs::File::open(&cli.workload)
+        .map_err(|e| anyhow::anyhow!("cannot open workload file: {e}"))?;
+    let sched_info: SchedInfo = serde_yaml::from_reader(file)
+        .map_err(|e| anyhow::anyhow!("failed to parse workload YAML: {e}"))?;
+
+    info!(
+        workload_id = %sched_info.workload_id,
+        task_count  = sched_info.tasks.len(),
+        "Workload loaded"
+    );
+    for (i, t) in sched_info.tasks.iter().enumerate() {
+        let policy_str = match t.policy {
+            0 => "NORMAL",
+            1 => "FIFO",
+            2 => "RR",
+            _ => "?",
+        };
+        info!(
+            "  [{i}] name={} node={} prio={} policy={} period={}us runtime={}us",
+            t.name, t.node_id, t.priority, policy_str, t.period, t.runtime
+        );
+    }
+
+    // ── Step 3: send AddSchedInfo to Timpani-O ────────────────────────────────
+    let sinfo_addr = format!("http://{}:{}", cli.sinfo_host, cli.sinfo_port);
+    info!("Connecting to Timpani-O SchedInfoService at {sinfo_addr}");
+
+    let mut client = SchedInfoServiceClient::connect(sinfo_addr)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "cannot connect to Timpani-O: {e}\n\
+            → Is Timpani-O running on {}:{}?",
+                cli.sinfo_host,
+                cli.sinfo_port
+            )
+        })?;
+
+    let response = client
+        .add_sched_info(Request::new(sched_info))
+        .await
+        .map_err(|s| anyhow::anyhow!("AddSchedInfo RPC failed: {s}"))?
+        .into_inner();
+
+    if response.status == 0 {
+        info!("✅  AddSchedInfo succeeded (status=0)");
+        info!("Timing-O should now be waiting for all nodes to call SyncTimer.");
+        info!("→ Start node-sim in another terminal.");
+    } else {
+        error!("❌  AddSchedInfo failed (status={})", response.status);
+    }
+
+    // ── Step 4: keep running to receive fault notifications ───────────────────
+    info!("Waiting for fault notifications from Timpani-O (Ctrl-C to stop)...");
+
+    tokio::signal::ctrl_c().await?;
+
+    info!("Shutdown signal received — stopping piccolo-sim");
+    let _ = shutdown_tx.send(true);
+
+    Ok(())
+}

--- a/timpani_rust/test-tools/src/bin/pullpiri_sim.rs
+++ b/timpani_rust/test-tools/src/bin/pullpiri_sim.rs
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
 SPDX-License-Identifier: MIT
 */
 
-//! piccolo-sim — manual test simulator for Piccolo's two roles:
+//! pullpiri-sim — manual test simulator for Pullpiri's two roles:
 //!
 //! **Role 1 — Client**: reads a workload YAML, sends `AddSchedInfo` to
 //! Timpani-O's upstream gRPC port.
@@ -16,14 +16,14 @@ SPDX-License-Identifier: MIT
 //! # Terminal 1: start Timpani-O first
 //! cargo run --bin timpani-o -- --nodeconfig ../../timpani-o/examples/node_configurations.yaml
 //!
-//! # Terminal 2: start piccolo-sim
-//! cargo run --bin piccolo-sim -- --workload test-tools/workloads/example_workload.yaml
+//! # Terminal 2: start pullpiri-sim
+//! cargo run --bin pullpiri-sim -- --workload test-tools/workloads/example_workload.yaml
 //!
 //! # Terminal 3: start node-sim (fires the sync barrier, then sends a deadline miss)
 //! cargo run --bin node-sim -- --nodes node01,node02,node03 --dmiss node01:task_safety
 //! ```
 //!
-//! piccolo-sim will then print:
+//! pullpiri-sim will then print:
 //!   ✅  AddSchedInfo succeeded
 //!   🔔  FAULT: workload=test_workload node=node01 task=task_safety type=DMISS
 
@@ -46,8 +46,8 @@ use timpani_o::proto::schedinfo_v1::{
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "piccolo-sim",
-    about = "Piccolo simulator: sends AddSchedInfo and receives fault notifications"
+    name = "pullpiri-sim",
+    about = "Pullpiri simulator: sends AddSchedInfo and receives fault notifications"
 )]
 struct Cli {
     /// Host where Timpani-O SchedInfoService is listening.
@@ -71,10 +71,10 @@ struct Cli {
 // ── FaultService implementation ───────────────────────────────────────────────
 
 /// Receives `NotifyFault` calls from Timpani-O and logs them.
-struct PiccoloFaultService;
+struct PullpiriFaultService;
 
 #[tonic::async_trait]
-impl FaultService for PiccoloFaultService {
+impl FaultService for PullpiriFaultService {
     async fn notify_fault(
         &self,
         request: Request<FaultInfo>,
@@ -128,7 +128,7 @@ async fn main() -> Result<()> {
     let fault_server = {
         let mut rx = shutdown_rx.clone();
         Server::builder()
-            .add_service(FaultServiceServer::new(PiccoloFaultService))
+            .add_service(FaultServiceServer::new(PullpiriFaultService))
             .serve_with_shutdown(fault_addr, async move {
                 while !*rx.borrow() {
                     rx.changed().await.ok();
@@ -203,7 +203,7 @@ async fn main() -> Result<()> {
 
     tokio::signal::ctrl_c().await?;
 
-    info!("Shutdown signal received — stopping piccolo-sim");
+    info!("Shutdown signal received — stopping pullpiri-sim");
     let _ = shutdown_tx.send(true);
 
     Ok(())

--- a/timpani_rust/test-tools/workloads/example_workload.yaml
+++ b/timpani_rust/test-tools/workloads/example_workload.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+# SPDX-License-Identifier: MIT
+
+# Example workload for piccolo-sim
+#
+# Field names match the proto definition in schedinfo.proto (TaskInfo message):
+#
+#   name          – task name (string)
+#   node_id       – target node, must match a key in node_configurations.yaml
+#   priority      – Linux real-time priority (1-99; higher = more urgent)
+#   policy        – sched policy: 0=NORMAL  1=SCHED_FIFO  2=SCHED_RR
+#   cpu_affinity  – bitmask; 0 means "any"
+#                   CPU0→1  CPU1→2  CPU2→4  CPU3→8  CPU4→16  CPU5→32
+#                   CPU6→64 CPU7→128
+#   period        – task period in microseconds
+#   runtime       – worst-case execution time in microseconds (≤ deadline)
+#   deadline      – relative deadline in microseconds (≤ period)
+#   release_time  – phase offset in microseconds (normally 0)
+#   max_dmiss     – allowed consecutive deadline misses (0 = none tolerated)
+#
+# To fire the full test chain:
+#   1. cargo run -p timpani-o -- --nodeconfig examples/node_configurations.yaml
+#   2. cargo run -p test-tools --bin piccolo-sim -- -w workloads/example_workload.yaml
+#   3. cargo run -p test-tools --bin node-sim  -- --nodes node01,node02,node03 \
+#          --dmiss node01:task_safety --dmiss-delay-ms 2000
+
+workload_id: "test_workload"
+
+tasks:
+  # ── node01 ────────────────────────────────────────────────────────────────
+  # Safety-critical control task: strict FIFO, no deadline misses allowed.
+  - name:         "task_safety"
+    node_id:      "node01"
+    priority:     80
+    policy:       1       # SCHED_FIFO
+    cpu_affinity: 0       # any available CPU
+    period:       10000   # 10 ms
+    runtime:      500     # 0.5 ms  (util = 5 %)
+    deadline:     10000
+    release_time: 0
+    max_dmiss:    0
+
+  # Sensor fusion: lower priority, tolerates occasional late completions.
+  - name:         "task_sensor"
+    node_id:      "node01"
+    priority:     70
+    policy:       1
+    cpu_affinity: 0
+    period:       20000   # 20 ms
+    runtime:      1000    # 1 ms   (util = 5 %)
+    deadline:     20000
+    release_time: 0
+    max_dmiss:    3
+
+  # ── node02 ────────────────────────────────────────────────────────────────
+  # High-frequency actuator control: tightest period, no misses allowed.
+  - name:         "task_control"
+    node_id:      "node02"
+    priority:     90
+    policy:       1
+    cpu_affinity: 0
+    period:       5000    # 5 ms
+    runtime:      200     # 0.2 ms  (util = 4 %)
+    deadline:     5000
+    release_time: 0
+    max_dmiss:    0
+
+  # System monitor: best-effort inside real-time envelope.
+  - name:         "task_monitor"
+    node_id:      "node02"
+    priority:     60
+    policy:       1
+    cpu_affinity: 0
+    period:       20000   # 20 ms
+    runtime:      2000    # 2 ms   (util = 10 %)
+    deadline:     20000
+    release_time: 0
+    max_dmiss:    5
+
+  # ── node03 ────────────────────────────────────────────────────────────────
+  # Navigation task: 40 ms period, moderate load.
+  - name:         "task_nav"
+    node_id:      "node03"
+    priority:     50
+    policy:       1
+    cpu_affinity: 0
+    period:       40000   # 40 ms
+    runtime:      3000    # 3 ms   (util = 7.5 %)
+    deadline:     40000
+    release_time: 0
+    max_dmiss:    3
+
+  # Communication handler: round-robin, lowest priority.
+  - name:         "task_comm"
+    node_id:      "node03"
+    priority:     40
+    policy:       2       # SCHED_RR
+    cpu_affinity: 0
+    period:       40000   # 40 ms
+    runtime:      2000    # 2 ms   (util = 5 %)
+    deadline:     40000
+    release_time: 0
+    max_dmiss:    5

--- a/timpani_rust/timpani-o/build.rs
+++ b/timpani_rust/timpani-o/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_root = "./proto";
 
     // All proto files to compile.
-    //   schedinfo.proto    — SchedInfoService (Piccolo → Timpani-O) + FaultService
+    //   schedinfo.proto    — SchedInfoService (Pullpiri → Timpani-O) + FaultService
     //   node_service.proto — NodeService (Timpani-N → Timpani-O)
     let proto_files = [
         format!("{}/schedinfo.proto", proto_root),
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         // Generate both server and client stubs for every service.
         // Servers: SchedInfoService, NodeService (Timpani-O serves these).
-        // Client:  FaultService (Timpani-O calls Piccolo).
+        // Client:  FaultService (Timpani-O calls Pullpiri).
         .build_server(true)
         .build_client(true)
         // Derive serde Serialize/Deserialize on every generated message so we can

--- a/timpani_rust/timpani-o/build.rs
+++ b/timpani_rust/timpani-o/build.rs
@@ -16,24 +16,38 @@ SPDX-License-Identifier: MIT
 /// Install on Ubuntu/Debian: `sudo apt install -y protobuf-compiler`
 /// Install on macOS:          `brew install protobuf`
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Path to the proto source relative to this crate's root
-    // (rust/timpani-o/ → ../../timpani-o/proto/)
-    let proto_root = "../../timpani-o/proto";
-    let proto_file = format!("{}/schedinfo.proto", proto_root);
+    // Path to the proto source relative to this crate's root.
+    // Both proto files now live inside the Rust project itself so that the
+    // crate can be built without the C++ tree present alongside it.
+    let proto_root = "./proto";
 
-    // Tell Cargo to re-run this build script when the proto file changes
-    println!("cargo:rerun-if-changed={}", proto_file);
+    // All proto files to compile.
+    //   schedinfo.proto    — SchedInfoService (Piccolo → Timpani-O) + FaultService
+    //   node_service.proto — NodeService (Timpani-N → Timpani-O)
+    let proto_files = [
+        format!("{}/schedinfo.proto", proto_root),
+        format!("{}/node_service.proto", proto_root),
+    ];
+
+    // Tell Cargo to re-run this build script when any proto file changes.
+    for f in &proto_files {
+        println!("cargo:rerun-if-changed={}", f);
+    }
+
+    let proto_refs: Vec<&str> = proto_files.iter().map(String::as_str).collect();
 
     tonic_build::configure()
-        // Generate both server (SchedInfoService) and client (FaultService) stubs
+        // Generate both server and client stubs for every service.
+        // Servers: SchedInfoService, NodeService (Timpani-O serves these).
+        // Client:  FaultService (Timpani-O calls Piccolo).
         .build_server(true)
         .build_client(true)
         // Derive serde Serialize/Deserialize on every generated message so we can
         // (de)serialise them easily in tests and logging.
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile_protos(
-            &[proto_file.as_str()], // proto files to compile
-            &[proto_root],          // directories to search for imports
+            &proto_refs,   // proto files to compile
+            &[proto_root], // directories to search for imports
         )?;
 
     Ok(())

--- a/timpani_rust/timpani-o/examples/node_configurations.yaml
+++ b/timpani_rust/timpani-o/examples/node_configurations.yaml
@@ -1,0 +1,28 @@
+# TTRT Global Scheduler - Node Configuration File
+# 각 노드의 하드웨어 사양 및 가용 리소스 정의
+
+nodes:
+  node01:
+    # 인지 및 센서 융합 노드 (4코어 시스템, CPU0 제외하고 끝쪽 3개 사용)
+    available_cpus: [2, 3]
+    max_memory_mb: 4096
+    architecture: "aarch64"
+    location: "front_sensor_unit"
+    description: "Autonomous driving perception and sensor fusion node"
+
+  node02:
+    # 차량 제어 및 안전 노드 (6코어 시스템, CPU0 제외하고 끝쪽 4개 사용)
+    available_cpus: [2, 3, 4, 5]
+    max_memory_mb: 8192
+    architecture: "aarch64"
+    location: "vehicle_control_unit"
+    description: "Motion control and safety-critical operations node"
+
+  node03:
+    # 통신 및 네비게이션 노드 (8코어 시스템, non-sequential CPU 사용)
+    available_cpus: [2, 3, 6, 7]
+    max_memory_mb: 4096
+    architecture: "x86_64"
+    location: "communication_unit"
+    description: "Communication, navigation and infotainment node"
+

--- a/timpani_rust/timpani-o/proto/node_service.proto
+++ b/timpani_rust/timpani-o/proto/node_service.proto
@@ -1,0 +1,176 @@
+syntax = "proto3";
+
+package schedinfo.v1;
+
+// ── Overview ──────────────────────────────────────────────────────────────────
+//
+// NodeService is served by Timpani-O and consumed by every Timpani-N node.
+// It replaces the D-Bus / libtrpc transport used in the C++ implementation.
+//
+// Timpani-N startup sequence:
+//   1. Connect to Timpani-O and call GetSchedInfo → receive its task list.
+//   2. Call SyncTimer → block until all active nodes in the workload have
+//      checked in.  Timpani-O responds to all callers simultaneously with the
+//      same absolute wall-clock start time.
+//   3. Arm a CLOCK_REALTIME timer for start_time and begin the RT loop.
+//   4. On every deadline miss: call ReportDMiss → Timpani-O forwards to
+//      Piccolo via FaultService.
+//
+// Design notes
+// ─────────────
+// • SyncTimer is a blocking unary RPC (server holds it open until all active
+//   nodes have called in).  This replaces the 100 ms polling loop that
+//   trpc_client_sync() used in the C++ implementation.
+// • GetSchedInfo filters by node_id and returns only that node's tasks.
+//   The C++ D-Bus path sent every node's tasks in one buffer; each Timpani-N
+//   had to scan for its own node_id.  The gRPC design is more efficient and
+//   avoids leaking other nodes' scheduling parameters across the network.
+// • DeadlineMissInfo mirrors the two arguments of trpc_client_dmiss() exactly:
+//   (node_id, task_name).  Timpani-O looks up the workload_id itself.
+
+service NodeService {
+  // Timpani-N calls this at startup to pull its assigned schedule.
+  // Returns only the tasks assigned to the requesting node.
+  // If no workload has been submitted yet, the server returns NOT_FOUND.
+  rpc GetSchedInfo (NodeSchedRequest) returns (NodeSchedResponse) {}
+
+  // Barrier synchronisation.  Timpani-N registers its readiness here.
+  // The server blocks the response until every node that received tasks in
+  // the active workload has called SyncTimer.  When all nodes have checked in,
+  // every pending SyncTimer call receives the same start_time simultaneously.
+  //
+  // Late-joiner behaviour: if the barrier has already been released for the
+  // current workload, the server responds immediately with the recorded
+  // start_time (which will be in the past).  Timpani-N is responsible for
+  // computing the next valid hyperperiod boundary as:
+  //   T₀ + ceil((now - T₀) / hyperperiod_us) * hyperperiod_us
+  //
+  // If the workload is replaced while a node is waiting, the RPC returns
+  // ABORTED so Timpani-N can reconnect and call GetSchedInfo again.
+  rpc SyncTimer (SyncRequest) returns (SyncResponse) {}
+
+  // Timpani-N calls this whenever a task misses its deadline.
+  // Timpani-O resolves the workload_id from its internal store and forwards
+  // the event to Piccolo via FaultService.NotifyFault.
+  rpc ReportDMiss (DeadlineMissInfo) returns (NodeResponse) {}
+}
+
+// ── GetSchedInfo ──────────────────────────────────────────────────────────────
+
+message NodeSchedRequest {
+  // Timpani-N node identifier.  Must match a key in node_configurations.yaml
+  // and must appear in the active workload's scheduled output.
+  string node_id = 1;
+}
+
+// A single task as output by GlobalScheduler, ready to apply via
+// sched_setscheduler / sched_setaffinity on the target node.
+//
+// Field names and units are chosen to match sched_task_t (schedinfo_service.h)
+// and task_info (timpani-n/src/schedinfo.h) directly, so that the Timpani-N
+// port can map fields without conversion.
+message ScheduledTask {
+  // Task name.  At most 16 characters in Timpani-N (TINFO_NAME_MAX) — not
+  // enforced by the proto but callers should be aware of the limit.
+  string name             = 1;
+
+  // Linux real-time scheduling priority (1–99 for FIFO/RR; 0 for NORMAL).
+  // Passed directly to sched_setattr / sched_setscheduler.
+  int32  sched_priority   = 2;
+
+  // Linux scheduling policy integer:
+  //   0 = SCHED_NORMAL (SCHED_OTHER)
+  //   1 = SCHED_FIFO
+  //   2 = SCHED_RR
+  // Stored as int32 to match the Linux ABI directly; no SchedPolicy enum
+  // import is needed on the Timpani-N side.
+  int32  sched_policy     = 3;
+
+  // Period in microseconds.  Timpani-N converts to ns for timer arming.
+  int32  period_us        = 4;
+
+  // Release time offset within the hyperperiod, in microseconds.
+  // Zero means "fire at the start of each hyperperiod cycle".
+  int32  release_time_us  = 5;
+
+  // Worst-case execution time budget (runtime) in microseconds.
+  // Used for SCHED_DEADLINE runtime parameter.
+  int32  runtime_us       = 6;
+
+  // Relative deadline in microseconds.
+  // Used for SCHED_DEADLINE deadline parameter and deadline-miss detection.
+  int32  deadline_us      = 7;
+
+  // CPU affinity bitmask: bit N set means the task may run on CPU N.
+  // 0 or 0xFFFFFFFF means "any CPU" (matches CpuAffinity::Any in Rust).
+  // Passed to sched_setaffinity / set_affinity_cpumask.
+  uint64 cpu_affinity     = 8;
+
+  // Maximum number of consecutive deadline misses before the node reports
+  // a fault to Timpani-O.
+  int32  max_dmiss        = 9;
+
+  // The node this task was assigned to by GlobalScheduler.
+  // Redundant when filtering per-node (it will always equal the requesting
+  // node_id), but included so the response is self-describing and so that
+  // multi-node debug dumps are unambiguous.
+  string assigned_node    = 10;
+}
+
+message NodeSchedResponse {
+  // Workload identifier this schedule was computed for.
+  string workload_id        = 1;
+
+  // Hyperperiod in microseconds — LCM of all task periods in this workload.
+  // Timpani-N uses this to initialise its hp_manager and set the outer timer.
+  uint64 hyperperiod_us     = 2;
+
+  // All tasks assigned to the requesting node, in the order produced by
+  // GlobalScheduler.  May be empty if the node was not needed for this
+  // workload (GetSchedInfo still succeeds; Timpani-N idles).
+  repeated ScheduledTask tasks = 3;
+}
+
+// ── SyncTimer ─────────────────────────────────────────────────────────────────
+
+message SyncRequest {
+  // Node declaring itself ready to start the RT loop.
+  string node_id = 1;
+}
+
+message SyncResponse {
+  // true  = all active nodes have checked in; start_time_* fields are valid.
+  // false = barrier timed out or was cancelled; caller should abort and retry.
+  bool  ack              = 1;
+
+  // Absolute start time for the first hyperperiod timer, split into seconds
+  // and nanoseconds to map directly to struct timespec used in Timpani-N.
+  // Clock domain: CLOCK_REALTIME (to be changed to CLOCK_TAI when gPTP is
+  // integrated — see DEVELOPER_NOTES.md D-020).
+  //
+  // Valid only when ack = true.
+  int64 start_time_sec   = 2;
+  int32 start_time_nsec  = 3;
+}
+
+// ── ReportDMiss ───────────────────────────────────────────────────────────────
+
+// Mirrors the two arguments of trpc_client_dmiss(dbus, node_id, taskname).
+// Timpani-O resolves workload_id internally from the current workload store
+// (it knows which tasks are on which node) before forwarding to Piccolo.
+message DeadlineMissInfo {
+  // Node where the miss occurred.
+  string node_id   = 1;
+  // Name of the task that missed its deadline.
+  string task_name = 2;
+}
+
+// Simple response for ReportDMiss.
+// Defined here rather than reusing schedinfo.v1.Response so that node_service
+// remains a self-contained proto that Timpani-N can depend on independently.
+message NodeResponse {
+  // 0 = success, non-zero = error.
+  int32  status        = 1;
+  // Human-readable error detail.  Empty on success.
+  string error_message = 2;
+}

--- a/timpani_rust/timpani-o/proto/schedinfo.proto
+++ b/timpani_rust/timpani-o/proto/schedinfo.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package schedinfo.v1;
+
+// SchedInfoService in Timpani-O
+service SchedInfoService {
+  // Add a new SchedInfo
+  // From Piccolo to Timpani-O
+  rpc AddSchedInfo (SchedInfo) returns (Response) {}
+}
+
+// FaultService in Piccolo
+service FaultService {
+  // Notify a fault
+  // From Timpani-O to Piccolo
+  rpc NotifyFault (FaultInfo) returns (Response) {}
+}
+
+// Common response message for SchedInfoService and FaultService
+message Response {
+  // Status code: 0 for success, non-zero for error
+  int32 status = 1;
+}
+
+enum SchedPolicy {
+  // SCHED_NORMAL
+  NORMAL = 0;
+  // SCHED_FIFO
+  FIFO = 1;
+  // SCHED_RR
+  RR = 2;
+}
+
+message TaskInfo {
+  // Unique task name
+  string name = 1;
+  // Task priority
+  int32 priority = 2;
+  // Scheduling policy
+  SchedPolicy policy = 3;
+  // CPU affinity
+  uint64 cpu_affinity = 4;
+  // Period in us
+  int32 period = 5;
+  // Release time in us
+  int32 release_time = 6;
+  // Runtime in us
+  int32 runtime = 7;
+  // Deadline in us
+  int32 deadline = 8;
+  // Node ID where the task is running
+  string node_id = 9;
+  // Maximum number of deadline misses allowed
+  int32 max_dmiss = 10;
+}
+
+message SchedInfo {
+  string workload_id = 1;
+  repeated TaskInfo tasks = 2;
+}
+
+enum FaultType {
+  // Unknown fault
+  UNKNOWN = 0;
+  // Deadline miss
+  DMISS = 1;
+}
+
+message FaultInfo {
+  string workload_id = 1;
+  string node_id = 2;
+  string task_name = 3;
+  FaultType type = 4;
+}

--- a/timpani_rust/timpani-o/src/config/mod.rs
+++ b/timpani_rust/timpani-o/src/config/mod.rs
@@ -220,6 +220,24 @@ impl NodeConfigManager {
     }
 }
 
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+impl NodeConfigManager {
+    /// Construct a `NodeConfigManager` directly from a list of `NodeConfig` values.
+    ///
+    /// Only available in test builds.  Use [`load_from_file`](Self::load_from_file)
+    /// in production.  This avoids the need for a temp file in unit tests that
+    /// require a populated node configuration.
+    pub fn from_nodes(nodes: Vec<NodeConfig>) -> Self {
+        let nodes_map = nodes.into_iter().map(|n| (n.name.clone(), n)).collect();
+        Self {
+            nodes: nodes_map,
+            loaded: true,
+        }
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/timpani_rust/timpani-o/src/fault/mod.rs
+++ b/timpani_rust/timpani-o/src/fault/mod.rs
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
 SPDX-License-Identifier: MIT
 */
 
-//! Fault notification client for Piccolo's `FaultService`.
+//! Fault notification client for Pullpiri's `FaultService`.
 //!
 //! # Design vs C++ implementation
 //!
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
 //! In the Rust port all callbacks are async closures with captured state,
 //! so the singleton pattern is unnecessary.  `FaultClient` is injected as
 //! `Arc<dyn FaultNotifier>` wherever it is needed.  This makes the component
-//! testable without a live Piccolo server.
+//! testable without a live Pullpiri server.
 
 use std::sync::Arc;
 
@@ -28,7 +28,7 @@ use crate::proto::schedinfo_v1::{
 
 // ── FaultNotification ─────────────────────────────────────────────────────────
 
-/// Data carried in every fault notification sent to Piccolo.
+/// Data carried in every fault notification sent to Pullpiri.
 #[derive(Debug, Clone)]
 pub struct FaultNotification {
     pub workload_id: String,
@@ -39,7 +39,7 @@ pub struct FaultNotification {
 
 // ── FaultError ────────────────────────────────────────────────────────────────
 
-/// Errors that can occur when notifying Piccolo of a fault.
+/// Errors that can occur when notifying Pullpiri of a fault.
 #[derive(Debug, Error)]
 pub enum FaultError {
     /// tonic channel / endpoint construction failure.
@@ -50,14 +50,14 @@ pub enum FaultError {
     #[error("RPC status: {0}")]
     Rpc(#[from] tonic::Status),
 
-    /// The RPC succeeded but Piccolo returned a non-zero status code.
-    #[error("Piccolo returned non-zero status {0}")]
+    /// The RPC succeeded but Pullpiri returned a non-zero status code.
+    #[error("Pullpiri returned non-zero status {0}")]
     RemoteError(i32),
 }
 
 // ── FaultNotifier trait ───────────────────────────────────────────────────────
 
-/// Async interface for sending fault notifications to Piccolo.
+/// Async interface for sending fault notifications to Pullpiri.
 ///
 /// Implemented by [`FaultClient`] in production and by
 /// [`test_support::MockFaultNotifier`] in tests.
@@ -68,7 +68,7 @@ pub trait FaultNotifier: Send + Sync {
 
 // ── FaultClient ───────────────────────────────────────────────────────────────
 
-/// Production gRPC client for Piccolo's `FaultService`.
+/// Production gRPC client for Pullpiri's `FaultService`.
 ///
 /// Created once at startup and shared via `Arc<dyn FaultNotifier>`.
 pub struct FaultClient {
@@ -81,7 +81,7 @@ impl FaultClient {
     /// Create a fault client that connects lazily to `addr`.
     ///
     /// The TCP connection is not established until the first RPC call.
-    /// This avoids a hard startup ordering dependency on Piccolo being live
+    /// This avoids a hard startup ordering dependency on Pullpiri being live
     /// when Timpani-O starts.
     ///
     /// `addr` must be a full URI, e.g. `"http://localhost:50053"`.
@@ -106,7 +106,7 @@ impl FaultNotifier for FaultClient {
             workload_id = %info.workload_id,
             node_id     = %info.node_id,
             task_name   = %info.task_name,
-            "Notifying Piccolo of fault"
+            "Notifying Pullpiri of fault"
         );
 
         // Clone is cheap — Channel is Arc-backed.
@@ -134,7 +134,7 @@ pub mod test_support {
     /// A no-op `FaultNotifier` that records calls.
     ///
     /// Use in unit tests to assert that the correct fault notifications are
-    /// generated without needing a live Piccolo server.
+    /// generated without needing a live Pullpiri server.
     pub struct MockFaultNotifier {
         pub calls: Mutex<Vec<FaultNotification>>,
     }

--- a/timpani_rust/timpani-o/src/fault/mod.rs
+++ b/timpani_rust/timpani-o/src/fault/mod.rs
@@ -1,0 +1,224 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! Fault notification client for Piccolo's `FaultService`.
+//!
+//! # Design vs C++ implementation
+//!
+//! The C++ used `FaultServiceClient::GetInstance()` — a Meyers singleton.
+//! The singleton existed only to work around the C-style static callback
+//! `DBusServer::DMissCallback`, which could not capture `this`.
+//!
+//! In the Rust port all callbacks are async closures with captured state,
+//! so the singleton pattern is unnecessary.  `FaultClient` is injected as
+//! `Arc<dyn FaultNotifier>` wherever it is needed.  This makes the component
+//! testable without a live Piccolo server.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tonic::transport::Channel;
+use tracing::info;
+
+use crate::proto::schedinfo_v1::{
+    fault_service_client::FaultServiceClient as ProtoFaultClient, FaultInfo, FaultType,
+};
+
+// ── FaultNotification ─────────────────────────────────────────────────────────
+
+/// Data carried in every fault notification sent to Piccolo.
+#[derive(Debug, Clone)]
+pub struct FaultNotification {
+    pub workload_id: String,
+    pub node_id: String,
+    pub task_name: String,
+    pub fault_type: FaultType,
+}
+
+// ── FaultError ────────────────────────────────────────────────────────────────
+
+/// Errors that can occur when notifying Piccolo of a fault.
+#[derive(Debug, Error)]
+pub enum FaultError {
+    /// tonic channel / endpoint construction failure.
+    #[error("transport error: {0}")]
+    Transport(#[from] tonic::transport::Error),
+
+    /// The gRPC call itself failed (network error, server unavailable, etc.).
+    #[error("RPC status: {0}")]
+    Rpc(#[from] tonic::Status),
+
+    /// The RPC succeeded but Piccolo returned a non-zero status code.
+    #[error("Piccolo returned non-zero status {0}")]
+    RemoteError(i32),
+}
+
+// ── FaultNotifier trait ───────────────────────────────────────────────────────
+
+/// Async interface for sending fault notifications to Piccolo.
+///
+/// Implemented by [`FaultClient`] in production and by
+/// [`test_support::MockFaultNotifier`] in tests.
+#[tonic::async_trait]
+pub trait FaultNotifier: Send + Sync {
+    async fn notify_fault(&self, info: FaultNotification) -> Result<(), FaultError>;
+}
+
+// ── FaultClient ───────────────────────────────────────────────────────────────
+
+/// Production gRPC client for Piccolo's `FaultService`.
+///
+/// Created once at startup and shared via `Arc<dyn FaultNotifier>`.
+pub struct FaultClient {
+    // tonic client stubs are `Clone` — they share the underlying Arc<Channel>.
+    // We clone on each call rather than wrapping in Mutex<...>.
+    stub: ProtoFaultClient<Channel>,
+}
+
+impl FaultClient {
+    /// Create a fault client that connects lazily to `addr`.
+    ///
+    /// The TCP connection is not established until the first RPC call.
+    /// This avoids a hard startup ordering dependency on Piccolo being live
+    /// when Timpani-O starts.
+    ///
+    /// `addr` must be a full URI, e.g. `"http://localhost:50053"`.
+    pub fn connect_lazy(addr: String) -> anyhow::Result<Arc<dyn FaultNotifier>> {
+        let channel = tonic::transport::Endpoint::from_shared(addr)?.connect_lazy();
+        let stub = ProtoFaultClient::new(channel);
+        Ok(Arc::new(Self { stub }))
+    }
+}
+
+#[tonic::async_trait]
+impl FaultNotifier for FaultClient {
+    async fn notify_fault(&self, info: FaultNotification) -> Result<(), FaultError> {
+        let request = FaultInfo {
+            workload_id: info.workload_id.clone(),
+            node_id: info.node_id.clone(),
+            task_name: info.task_name.clone(),
+            r#type: info.fault_type as i32,
+        };
+
+        info!(
+            workload_id = %info.workload_id,
+            node_id     = %info.node_id,
+            task_name   = %info.task_name,
+            "Notifying Piccolo of fault"
+        );
+
+        // Clone is cheap — Channel is Arc-backed.
+        let mut stub = self.stub.clone();
+        let response = stub
+            .notify_fault(tonic::Request::new(request))
+            .await?
+            .into_inner();
+
+        if response.status != 0 {
+            return Err(FaultError::RemoteError(response.status));
+        }
+
+        Ok(())
+    }
+}
+
+// ── Test support ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A no-op `FaultNotifier` that records calls.
+    ///
+    /// Use in unit tests to assert that the correct fault notifications are
+    /// generated without needing a live Piccolo server.
+    pub struct MockFaultNotifier {
+        pub calls: Mutex<Vec<FaultNotification>>,
+    }
+
+    impl MockFaultNotifier {
+        /// Returns a typed `Arc<Self>` so tests can inspect `.calls` directly.
+        pub fn arc() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[tonic::async_trait]
+    impl FaultNotifier for MockFaultNotifier {
+        async fn notify_fault(&self, info: FaultNotification) -> Result<(), FaultError> {
+            tracing::debug!(
+                task = %info.task_name,
+                node = %info.node_id,
+                "MockFaultNotifier: recording fault (suppressed in test)"
+            );
+            self.calls.lock().unwrap().push(info);
+            Ok(())
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::MockFaultNotifier;
+    use super::*;
+    use crate::proto::schedinfo_v1::FaultType;
+
+    fn make_notification(workload_id: &str) -> FaultNotification {
+        FaultNotification {
+            workload_id: workload_id.into(),
+            node_id: "node01".into(),
+            task_name: "task_safety".into(),
+            fault_type: FaultType::Dmiss,
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_notifier_records_single_call() {
+        let notifier = MockFaultNotifier::arc();
+        notifier
+            .notify_fault(make_notification("wl1"))
+            .await
+            .unwrap();
+        let calls = notifier.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].workload_id, "wl1");
+        assert_eq!(calls[0].task_name, "task_safety");
+    }
+
+    #[tokio::test]
+    async fn mock_notifier_records_multiple_calls() {
+        let notifier = MockFaultNotifier::arc();
+        for i in 0..5_u32 {
+            notifier
+                .notify_fault(make_notification(&format!("wl{i}")))
+                .await
+                .unwrap();
+        }
+        assert_eq!(notifier.calls.lock().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn fault_error_remote_error_display() {
+        let e = FaultError::RemoteError(42);
+        assert!(e.to_string().contains("42"));
+    }
+
+    #[test]
+    fn fault_error_rpc_status_display() {
+        let e = FaultError::Rpc(tonic::Status::not_found("msg"));
+        assert!(!e.to_string().is_empty());
+    }
+
+    #[tokio::test]
+    async fn fault_client_connect_lazy_valid_uri_succeeds() {
+        FaultClient::connect_lazy("http://localhost:59999".to_string())
+            .expect("valid URI should not fail");
+    }
+}

--- a/timpani_rust/timpani-o/src/grpc/mod.rs
+++ b/timpani_rust/timpani-o/src/grpc/mod.rs
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
 //! # Concurrency model
 //!
 //! ```text
-//!   Piccolo ──AddSchedInfo──► SchedInfoServiceImpl
+//!   Pullpiri ──AddSchedInfo──► SchedInfoServiceImpl
 //!                                     │  writes
 //!                                     ▼
 //!                             WorkloadStore  (Arc<Mutex<Option<WorkloadState>>>)

--- a/timpani_rust/timpani-o/src/grpc/mod.rs
+++ b/timpani_rust/timpani-o/src/grpc/mod.rs
@@ -1,0 +1,211 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! gRPC service wiring — shared state and service module roots.
+//!
+//! Both gRPC services ([`schedinfo_service`] and [`node_service`]) share a
+//! single [`WorkloadStore`] that holds the currently active schedule.
+//!
+//! # Concurrency model
+//!
+//! ```text
+//!   Piccolo ──AddSchedInfo──► SchedInfoServiceImpl
+//!                                     │  writes
+//!                                     ▼
+//!                             WorkloadStore  (Arc<Mutex<Option<WorkloadState>>>)
+//!                                     │  reads
+//!                                     ▼
+//!   Timpani-N ──GetSchedInfo──► NodeServiceImpl
+//!   Timpani-N ──SyncTimer    ──► NodeServiceImpl  (holds watch::Receiver)
+//!   Timpani-N ──ReportDMiss  ──► NodeServiceImpl
+//! ```
+//!
+//! The `Mutex` is held briefly: only while reading/writing `WorkloadState`.
+//! `SyncTimer` acquires the lock to register the node and obtain a
+//! `watch::Receiver`, then releases it before awaiting the barrier.
+
+pub mod node_service;
+pub mod schedinfo_service;
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use tokio::sync::{watch, Mutex};
+
+use crate::hyperperiod::HyperperiodInfo;
+use crate::task::NodeSchedMap;
+
+// ── BarrierStatus ─────────────────────────────────────────────────────────────
+
+/// State of the SyncTimer synchronisation barrier for the active workload.
+///
+/// Sent over a `tokio::sync::watch` channel so that all waiting `SyncTimer`
+/// handlers wake up simultaneously when the barrier fires.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BarrierStatus {
+    /// Waiting for all active nodes to call `SyncTimer`.
+    Waiting,
+
+    /// All nodes have checked in.  Every RT loop must arm its first timer
+    /// for this absolute `CLOCK_REALTIME` time.
+    Released {
+        start_time_sec: i64,
+        start_time_nsec: i32,
+    },
+
+    /// The workload was replaced before the barrier fired.
+    /// Waiting handlers should abort with `Status::aborted`.
+    Cancelled,
+
+    /// No response from all nodes before the configured deadline.
+    /// Waiting handlers should return `Status::deadline_exceeded`.
+    TimedOut,
+}
+
+// ── WorkloadState ─────────────────────────────────────────────────────────────
+
+/// All per-workload state shared between the two gRPC services.
+///
+/// Created by `SchedInfoService` when a new workload arrives and stored inside
+/// the [`WorkloadStore`].  Dropped (with [`BarrierStatus::Cancelled`] broadcast)
+/// when the next workload replaces it.
+pub struct WorkloadState {
+    /// Workload identifier from the `AddSchedInfo` proto request.
+    pub workload_id: String,
+
+    /// Per-node scheduled task lists produced by `GlobalScheduler`.
+    /// `NodeSchedMap = HashMap<node_id, Vec<SchedTask>>`
+    pub schedule: NodeSchedMap,
+
+    /// Hyperperiod computed before scheduling.
+    pub hyperperiod: HyperperiodInfo,
+
+    /// Nodes that received at least one task — the expected `SyncTimer` callers.
+    /// Derived from `schedule.keys()` at construction time.
+    pub active_nodes: BTreeSet<String>,
+
+    /// Nodes that have called `SyncTimer` and are waiting for the barrier.
+    pub synced_nodes: BTreeSet<String>,
+
+    /// Barrier broadcast channel.
+    ///
+    /// Transitions:
+    ///   `Waiting` → `Released { ... }` when all active nodes have synced.
+    ///   `Waiting` → `Cancelled`        when a new workload replaces this one.
+    ///
+    /// `NodeService::sync_timer` subscribes to this sender while holding the
+    /// `WorkloadStore` lock, then awaits the receiver after releasing the lock.
+    pub barrier_tx: watch::Sender<BarrierStatus>,
+}
+
+impl WorkloadState {
+    /// Construct a fresh `WorkloadState` for a newly scheduled workload.
+    ///
+    /// `active_nodes` is derived from the keys of `schedule` — only nodes
+    /// that actually received tasks must participate in the sync barrier.
+    pub fn new(workload_id: String, schedule: NodeSchedMap, hyperperiod: HyperperiodInfo) -> Self {
+        let active_nodes: BTreeSet<String> = schedule.keys().cloned().collect();
+        let (barrier_tx, _) = watch::channel(BarrierStatus::Waiting);
+        Self {
+            workload_id,
+            schedule,
+            hyperperiod,
+            active_nodes,
+            synced_nodes: BTreeSet::new(),
+            barrier_tx,
+        }
+    }
+}
+
+// ── WorkloadStore ─────────────────────────────────────────────────────────────
+
+/// The single shared mutable state.
+///
+/// ```text
+/// Arc<Mutex<Option<WorkloadState>>>
+///  │    │      └─ None = no workload submitted yet
+///  │    └─ tokio async Mutex: held across .await only when strictly needed
+///  └─ shared by SchedInfoService, NodeService, and main
+/// ```
+pub type WorkloadStore = Arc<Mutex<Option<WorkloadState>>>;
+
+/// Construct an empty `WorkloadStore`.
+pub fn new_workload_store() -> WorkloadStore {
+    Arc::new(Mutex::new(None))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task::NodeSchedMap;
+
+    fn dummy_hyperperiod() -> HyperperiodInfo {
+        HyperperiodInfo {
+            workload_id: "wl".into(),
+            hyperperiod_us: 10_000,
+            unique_periods: vec![10_000],
+            task_count: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn new_workload_store_is_initially_none() {
+        let store = new_workload_store();
+        assert!(store.lock().await.is_none());
+    }
+
+    #[test]
+    fn workload_state_new_derives_active_nodes_from_schedule_keys() {
+        let mut schedule = NodeSchedMap::new();
+        schedule.insert("node01".into(), vec![]);
+        schedule.insert("node02".into(), vec![]);
+
+        let state = WorkloadState::new("wl1".into(), schedule, dummy_hyperperiod());
+
+        assert_eq!(state.workload_id, "wl1");
+        assert_eq!(state.active_nodes.len(), 2);
+        assert!(state.active_nodes.contains("node01"));
+        assert!(state.active_nodes.contains("node02"));
+        assert!(state.synced_nodes.is_empty());
+    }
+
+    #[test]
+    fn workload_state_new_empty_schedule_has_no_active_nodes() {
+        let state = WorkloadState::new("wl_empty".into(), NodeSchedMap::new(), dummy_hyperperiod());
+        assert!(state.active_nodes.is_empty());
+    }
+
+    #[test]
+    fn barrier_status_equality_and_inequality() {
+        assert_eq!(BarrierStatus::Waiting, BarrierStatus::Waiting);
+        assert_eq!(BarrierStatus::Cancelled, BarrierStatus::Cancelled);
+        assert_eq!(
+            BarrierStatus::Released {
+                start_time_sec: 42,
+                start_time_nsec: 0
+            },
+            BarrierStatus::Released {
+                start_time_sec: 42,
+                start_time_nsec: 0
+            },
+        );
+        assert_eq!(BarrierStatus::TimedOut, BarrierStatus::TimedOut);
+        assert_ne!(BarrierStatus::Waiting, BarrierStatus::Cancelled);
+        assert_ne!(BarrierStatus::Waiting, BarrierStatus::TimedOut);
+        assert_ne!(BarrierStatus::Cancelled, BarrierStatus::TimedOut);
+        assert_ne!(
+            BarrierStatus::Released {
+                start_time_sec: 1,
+                start_time_nsec: 0
+            },
+            BarrierStatus::Released {
+                start_time_sec: 2,
+                start_time_nsec: 0
+            },
+        );
+    }
+}

--- a/timpani_rust/timpani-o/src/grpc/node_service.rs
+++ b/timpani_rust/timpani-o/src/grpc/node_service.rs
@@ -1,0 +1,940 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! `NodeService` gRPC server — serves Timpani-N nodes.
+//!
+//! Three RPCs (mirroring the D-Bus / libtrpc interface from the C++ port):
+//!
+//! | RPC           | C++ equivalent              | Purpose                              |
+//! |---------------|-----------------------------|--------------------------------------|
+//! | `GetSchedInfo`  | `trpc_client_schedinfo`   | Timpani-N pulls its task list        |
+//! | `SyncTimer`     | `trpc_client_sync`        | Barrier — all nodes start together   |
+//! | `ReportDMiss`   | `trpc_client_dmiss`       | Deadline miss forwarded to Piccolo   |
+//!
+//! # SyncTimer barrier design
+//!
+//! `SyncTimer` is a blocking unary RPC.  When a node calls it:
+//!
+//! 1. The handler acquires `WorkloadStore`, registers the node in
+//!    `synced_nodes`, and subscribes to `barrier_tx` — **all under the same
+//!    lock hold** so a fast-firing barrier cannot be missed.
+//! 2. If this node completes the set (`synced_nodes == active_nodes`), it
+//!    broadcasts `Released { start_time_* }` on the watch channel.
+//! 3. Every pending `SyncTimer` handler wakes from `changed().await` and
+//!    returns the same `start_time` to its caller.
+//!
+//! The lock is **not** held during the `changed().await` wait, so it does not
+//! block concurrent `GetSchedInfo` or `ReportDMiss` calls.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
+
+use crate::fault::{FaultNotification, FaultNotifier};
+use crate::proto::schedinfo_v1::{
+    node_service_server::NodeService, DeadlineMissInfo, FaultType, NodeResponse, NodeSchedRequest,
+    NodeSchedResponse, ScheduledTask, SyncRequest, SyncResponse,
+};
+
+use super::{BarrierStatus, WorkloadStore};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Offset added to `now` when computing the barrier start time.
+///
+/// Gives every Timpani-N node time to receive the `SyncResponse` and arm its
+/// first hyperperiod timer before the start instant arrives.
+/// Matches the C++ `ts->tv_sec += 1` in `SyncCallback`.
+const SYNC_START_OFFSET_NS: i64 = 1_000_000_000; // 1 second
+
+/// Default timeout for the SyncTimer barrier.
+///
+/// If not all active nodes call `SyncTimer` within this window, the barrier is
+/// cancelled and every waiting handler returns `Status::DEADLINE_EXCEEDED`.
+/// Configurable via `--sync-timeout-secs` on the CLI.
+pub const DEFAULT_SYNC_TIMEOUT_SECS: u64 = 30;
+
+// ── Service struct ────────────────────────────────────────────────────────────
+
+/// tonic implementation of `NodeService`.
+///
+/// `Clone` is required by tonic.  All fields are `Arc`-wrapped.
+#[derive(Clone)]
+pub struct NodeServiceImpl {
+    workload_store: WorkloadStore,
+    fault_notifier: Arc<dyn FaultNotifier>,
+    sync_timeout: Duration,
+}
+
+impl NodeServiceImpl {
+    pub fn new(
+        workload_store: WorkloadStore,
+        fault_notifier: Arc<dyn FaultNotifier>,
+        sync_timeout: Duration,
+    ) -> Self {
+        Self {
+            workload_store,
+            fault_notifier,
+            sync_timeout,
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Compute an absolute `CLOCK_REALTIME` start time `SYNC_START_OFFSET_NS` in
+/// the future.  Returns `(seconds, nanoseconds)` matching `struct timespec`.
+fn compute_start_time() -> (i64, i32) {
+    let now_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i64;
+    let start_ns = now_ns + SYNC_START_OFFSET_NS;
+    (start_ns / 1_000_000_000, (start_ns % 1_000_000_000) as i32)
+}
+
+/// Convert an internal `SchedTask` to the proto wire type `ScheduledTask`.
+///
+/// `period_ns / 1_000` converts back to microseconds because `ScheduledTask`
+/// carries µs (matching `task_info.period` in Timpani-N's C headers).
+///
+/// `cpu_affinity` is encoded as a single-bit mask (`1 << assigned_cpu`)
+/// because the scheduler picked a specific CPU; Timpani-N calls
+/// `set_affinity_cpumask` with this value.
+fn to_proto_task(t: &crate::task::SchedTask) -> ScheduledTask {
+    ScheduledTask {
+        name: t.name.clone(),
+        sched_priority: t.priority,
+        sched_policy: t.policy.to_linux_int(),
+        period_us: (t.period_ns / 1_000) as i32,
+        release_time_us: t.release_time_us,
+        runtime_us: (t.runtime_ns / 1_000) as i32,
+        deadline_us: (t.deadline_ns / 1_000) as i32,
+        cpu_affinity: 1u64 << t.assigned_cpu,
+        max_dmiss: t.max_dmiss,
+        assigned_node: t.assigned_node.clone(),
+    }
+}
+
+// ── NodeService implementation ────────────────────────────────────────────────
+
+#[tonic::async_trait]
+impl NodeService for NodeServiceImpl {
+    // ── GetSchedInfo ──────────────────────────────────────────────────────────
+
+    async fn get_sched_info(
+        &self,
+        request: Request<NodeSchedRequest>,
+    ) -> Result<Response<NodeSchedResponse>, Status> {
+        let node_id = request.into_inner().node_id;
+        info!(node_id = %node_id, "GetSchedInfo request");
+
+        let guard = self.workload_store.lock().await;
+        let ws = guard.as_ref().ok_or_else(|| {
+            warn!(node_id = %node_id, "GetSchedInfo: no workload scheduled yet");
+            Status::not_found("no workload has been scheduled yet")
+        })?;
+
+        // Return this node's task list.  If the node received no tasks, return
+        // an empty list (not an error — the node can legitimately idle).
+        let tasks: Vec<ScheduledTask> = ws
+            .schedule
+            .get(&node_id)
+            .map(|v| v.iter().map(to_proto_task).collect())
+            .unwrap_or_default();
+
+        info!(
+            node_id     = %node_id,
+            workload_id = %ws.workload_id,
+            task_count  = tasks.len(),
+            "GetSchedInfo: serving schedule"
+        );
+
+        Ok(Response::new(NodeSchedResponse {
+            workload_id: ws.workload_id.clone(),
+            hyperperiod_us: ws.hyperperiod.hyperperiod_us,
+            tasks,
+        }))
+    }
+
+    // ── SyncTimer ─────────────────────────────────────────────────────────────
+
+    async fn sync_timer(
+        &self,
+        request: Request<SyncRequest>,
+    ) -> Result<Response<SyncResponse>, Status> {
+        let node_id = request.into_inner().node_id;
+        info!(node_id = %node_id, "SyncTimer: node checking in");
+
+        // ── Phase 1: register the node and obtain a barrier receiver ──────────
+        //
+        // The receiver is obtained INSIDE the lock so we cannot miss a
+        // Released notification that fires concurrently.  The lock is released
+        // before the async wait in Phase 2.
+        let mut barrier_rx = {
+            let mut guard = self.workload_store.lock().await;
+            let ws = guard
+                .as_mut()
+                .ok_or_else(|| Status::not_found("no workload has been scheduled yet"))?;
+
+            if ws.active_nodes.is_empty() {
+                return Err(Status::failed_precondition("workload has no active nodes"));
+            }
+            if !ws.active_nodes.contains(&node_id) {
+                warn!(
+                    node_id = %node_id,
+                    "SyncTimer: node is not part of the active workload"
+                );
+                return Err(Status::not_found(format!(
+                    "node '{}' did not receive any tasks in the active workload",
+                    node_id
+                )));
+            }
+
+            // Subscribe before potentially firing so we cannot miss Released.
+            let rx = ws.barrier_tx.subscribe();
+
+            ws.synced_nodes.insert(node_id.clone());
+
+            let all_synced = ws.active_nodes.iter().all(|n| ws.synced_nodes.contains(n));
+
+            if all_synced {
+                let (sec, nsec) = compute_start_time();
+                let _ = ws.barrier_tx.send(BarrierStatus::Released {
+                    start_time_sec: sec,
+                    start_time_nsec: nsec,
+                });
+                info!(
+                    workload_id = %ws.workload_id,
+                    node_count  = ws.active_nodes.len(),
+                    start_sec   = sec,
+                    "SyncTimer: barrier fired — all nodes ready"
+                );
+            } else {
+                let waiting: Vec<&String> = ws
+                    .active_nodes
+                    .iter()
+                    .filter(|n| !ws.synced_nodes.contains(*n))
+                    .collect();
+                info!(
+                    node_id = %node_id,
+                    ?waiting,
+                    "SyncTimer: registered, waiting for remaining nodes"
+                );
+            }
+
+            rx
+        }; // WorkloadStore lock released here
+
+        // ── Phase 2: wait for the barrier ─────────────────────────────────────
+        //
+        // `borrow_and_update()` marks the current value as "seen" so that
+        // `changed()` fires only on the NEXT state transition — no spurious
+        // wake-ups.
+        //
+        // A `tokio::time::sleep` races against every `changed()` call.  The
+        // future is pinned once so the deadline advances correctly across loop
+        // iterations.  The first handler to hit the deadline broadcasts
+        // `TimedOut` on the shared channel so all other waiters also wake up.
+        let timeout_sleep = tokio::time::sleep(self.sync_timeout);
+        tokio::pin!(timeout_sleep);
+
+        loop {
+            let status = (*barrier_rx.borrow_and_update()).clone();
+
+            match status {
+                BarrierStatus::Released {
+                    start_time_sec,
+                    start_time_nsec,
+                } => {
+                    info!(
+                        node_id   = %node_id,
+                        start_sec = start_time_sec,
+                        "SyncTimer: ack sent"
+                    );
+                    return Ok(Response::new(SyncResponse {
+                        ack: true,
+                        start_time_sec,
+                        start_time_nsec,
+                    }));
+                }
+                BarrierStatus::Cancelled => {
+                    warn!(
+                        node_id = %node_id,
+                        "SyncTimer: workload replaced while waiting — aborting"
+                    );
+                    return Err(Status::aborted(
+                        "workload was replaced while waiting for the sync barrier",
+                    ));
+                }
+                BarrierStatus::TimedOut => {
+                    warn!(
+                        node_id = %node_id,
+                        "SyncTimer: barrier timed out — returning deadline exceeded"
+                    );
+                    return Err(Status::deadline_exceeded(
+                        "sync barrier timed out waiting for all nodes to check in",
+                    ));
+                }
+                BarrierStatus::Waiting => {
+                    // Not all nodes have checked in yet — wait.
+                }
+            }
+
+            tokio::select! {
+                result = barrier_rx.changed() => {
+                    if result.is_err() {
+                        // The Sender was dropped (workload replaced after Cancelled was
+                        // sent and before this handler woke up).
+                        return Err(Status::aborted("sync barrier channel closed unexpectedly"));
+                    }
+                }
+                _ = &mut timeout_sleep => {
+                    warn!(
+                        node_id      = %node_id,
+                        timeout_secs = self.sync_timeout.as_secs(),
+                        "SyncTimer: timeout — broadcasting TimedOut to all waiting nodes"
+                    );
+                    // Wake all other handlers that are waiting on this barrier.
+                    {
+                        let guard = self.workload_store.lock().await;
+                        if let Some(ws) = guard.as_ref() {
+                            let _ = ws.barrier_tx.send(BarrierStatus::TimedOut);
+                        }
+                    }
+                    return Err(Status::deadline_exceeded(format!(
+                        "sync barrier timed out after {}s — not all nodes checked in",
+                        self.sync_timeout.as_secs(),
+                    )));
+                }
+            }
+        }
+    }
+
+    // ── ReportDMiss ───────────────────────────────────────────────────────────
+
+    async fn report_d_miss(
+        &self,
+        request: Request<DeadlineMissInfo>,
+    ) -> Result<Response<NodeResponse>, Status> {
+        let info = request.into_inner();
+        let node_id = info.node_id.clone();
+        let task_name = info.task_name.clone();
+
+        warn!(
+            node_id   = %node_id,
+            task_name = %task_name,
+            "DeadlineMiss reported"
+        );
+
+        // Resolve workload_id from the active schedule.
+        // If the task is not found (race with workload replacement), fall back
+        // to the current workload_id — mirrors the C++ DMissCallback fallback.
+        let workload_id = {
+            let guard = self.workload_store.lock().await;
+            match guard.as_ref() {
+                None => {
+                    warn!("ReportDMiss: no active workload");
+                    return Ok(Response::new(NodeResponse {
+                        status: -1,
+                        error_message: "no active workload".into(),
+                    }));
+                }
+                Some(ws) => {
+                    let found = ws
+                        .schedule
+                        .get(&node_id)
+                        .and_then(|tasks| tasks.iter().find(|t| t.name == task_name))
+                        .is_some();
+
+                    if !found {
+                        warn!(
+                            node_id   = %node_id,
+                            task_name = %task_name,
+                            "ReportDMiss: task not found in schedule; \
+                             using current workload_id as fallback"
+                        );
+                    }
+                    ws.workload_id.clone()
+                }
+            }
+        };
+
+        // Forward the fault to Piccolo.
+        let notification = FaultNotification {
+            workload_id,
+            node_id,
+            task_name,
+            fault_type: FaultType::Dmiss,
+        };
+
+        if let Err(e) = self.fault_notifier.notify_fault(notification).await {
+            error!(error = %e, "Failed to notify Piccolo of deadline miss");
+            return Ok(Response::new(NodeResponse {
+                status: -1,
+                error_message: format!("fault notification failed: {e}"),
+            }));
+        }
+
+        Ok(Response::new(NodeResponse {
+            status: 0,
+            error_message: String::new(),
+        }))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tonic::Request;
+
+    use crate::config::{NodeConfig, NodeConfigManager};
+    use crate::fault::{
+        test_support::MockFaultNotifier, FaultError, FaultNotification, FaultNotifier,
+    };
+    use crate::grpc::{new_workload_store, schedinfo_service::SchedInfoServiceImpl};
+    use crate::proto::schedinfo_v1::{
+        node_service_server::NodeService, sched_info_service_server::SchedInfoService,
+        DeadlineMissInfo, NodeSchedRequest, SchedInfo, SyncRequest, TaskInfo,
+    };
+
+    use super::{NodeServiceImpl, DEFAULT_SYNC_TIMEOUT_SECS};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn two_node_config() -> Arc<NodeConfigManager> {
+        Arc::new(NodeConfigManager::from_nodes(vec![
+            NodeConfig {
+                name: "n1".into(),
+                available_cpus: vec![0, 1],
+                max_memory_mb: 4096,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "".into(),
+            },
+            NodeConfig {
+                name: "n2".into(),
+                available_cpus: vec![0, 1],
+                max_memory_mb: 4096,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "".into(),
+            },
+        ]))
+    }
+
+    fn task_for(name: &str, node: &str) -> TaskInfo {
+        TaskInfo {
+            name: name.into(),
+            node_id: node.into(),
+            priority: 50,
+            policy: 1,
+            cpu_affinity: 0,
+            period: 10_000,
+            runtime: 1_000,
+            deadline: 10_000,
+            release_time: 0,
+            max_dmiss: 3,
+        }
+    }
+
+    /// Returns both services sharing one WorkloadStore plus the raw mock for inspection.
+    fn test_services() -> (
+        SchedInfoServiceImpl,
+        NodeServiceImpl,
+        Arc<MockFaultNotifier>,
+    ) {
+        let store = new_workload_store();
+        let mock = MockFaultNotifier::arc();
+        let svc = SchedInfoServiceImpl::new(
+            two_node_config(),
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+        );
+        let node_svc = NodeServiceImpl::new(
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+            Duration::from_secs(DEFAULT_SYNC_TIMEOUT_SECS),
+        );
+        (svc, node_svc, mock)
+    }
+
+    // ── GetSchedInfo ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_sched_info_no_workload_returns_not_found() {
+        let (_, node_svc, _) = test_services();
+        let err = node_svc
+            .get_sched_info(Request::new(NodeSchedRequest {
+                node_id: "n1".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn get_sched_info_returns_tasks_for_requesting_node() {
+        let (svc, node_svc, _) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1"), task_for("t2", "n2")],
+        }))
+        .await
+        .unwrap();
+
+        let resp = node_svc
+            .get_sched_info(Request::new(NodeSchedRequest {
+                node_id: "n1".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.workload_id, "wl");
+        assert_eq!(resp.tasks.len(), 1);
+        assert_eq!(resp.tasks[0].name, "t1");
+        assert!(resp.hyperperiod_us > 0);
+    }
+
+    #[tokio::test]
+    async fn get_sched_info_unknown_node_returns_empty_task_list() {
+        let (svc, node_svc, _) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let resp = node_svc
+            .get_sched_info(Request::new(NodeSchedRequest {
+                node_id: "no_such_node".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // Unknown node is not an error — it just receives an empty task list.
+        assert!(resp.tasks.is_empty());
+    }
+
+    // ── SyncTimer ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sync_timer_no_workload_returns_not_found() {
+        let (_, node_svc, _) = test_services();
+        let err = node_svc
+            .sync_timer(Request::new(SyncRequest {
+                node_id: "n1".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn sync_timer_unknown_node_returns_not_found() {
+        let (svc, node_svc, _) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let err = node_svc
+            .sync_timer(Request::new(SyncRequest {
+                node_id: "unknown_node".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn sync_timer_single_node_workload_fires_barrier_immediately() {
+        let (svc, node_svc, _) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let resp = node_svc
+            .sync_timer(Request::new(SyncRequest {
+                node_id: "n1".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.ack);
+        assert!(
+            resp.start_time_sec > 0,
+            "start_time should be a real timestamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_timer_all_nodes_receive_identical_start_time() {
+        let (svc, node_svc, _) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1"), task_for("t2", "n2")],
+        }))
+        .await
+        .unwrap();
+
+        let nsvc1 = node_svc.clone();
+        let nsvc2 = node_svc.clone();
+
+        let (r1, r2) = tokio::join!(
+            nsvc1.sync_timer(Request::new(SyncRequest {
+                node_id: "n1".into()
+            })),
+            nsvc2.sync_timer(Request::new(SyncRequest {
+                node_id: "n2".into()
+            })),
+        );
+
+        let s1 = r1.unwrap().into_inner();
+        let s2 = r2.unwrap().into_inner();
+
+        assert!(s1.ack && s2.ack);
+        assert_eq!(
+            s1.start_time_sec, s2.start_time_sec,
+            "all nodes must share the same start second"
+        );
+        assert_eq!(
+            s1.start_time_nsec, s2.start_time_nsec,
+            "all nodes must share the same start nanosecond"
+        );
+    }
+
+    // ── SyncTimer timeout ─────────────────────────────────────────────────────
+
+    /// When a node joins the barrier but a second node never arrives, the
+    /// barrier must fire `TimedOut` and return `DEADLINE_EXCEEDED` to the
+    /// waiting node.
+    #[tokio::test]
+    async fn sync_timer_returns_deadline_exceeded_when_timeout_fires() {
+        let store = new_workload_store();
+        let mock = MockFaultNotifier::arc();
+        let svc = SchedInfoServiceImpl::new(
+            two_node_config(),
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+        );
+        // Very short timeout so the test runs quickly.
+        let node_svc = NodeServiceImpl::new(
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+            Duration::from_millis(50),
+        );
+
+        // Two-node workload: n2 never calls SyncTimer, so n1 must time out.
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1"), task_for("t2", "n2")],
+        }))
+        .await
+        .unwrap();
+
+        let err = tokio::time::timeout(
+            Duration::from_secs(2),
+            node_svc.sync_timer(Request::new(SyncRequest {
+                node_id: "n1".into(),
+            })),
+        )
+        .await
+        .expect("sync_timer should complete within 2s")
+        .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    /// When the timeout fires while multiple nodes are waiting, the broadcast
+    /// ensures **all** waiters receive `DEADLINE_EXCEEDED`, not just the node
+    /// whose handler happened to own the sleep future.
+    #[tokio::test]
+    async fn sync_timer_timeout_wakes_all_waiting_nodes() {
+        // Three-node workload; n1 and n2 join but n3 never does.
+        let ncm = NodeConfigManager::from_nodes(vec![
+            NodeConfig {
+                name: "n1".into(),
+                available_cpus: vec![0],
+                max_memory_mb: 1024,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "".into(),
+            },
+            NodeConfig {
+                name: "n2".into(),
+                available_cpus: vec![0],
+                max_memory_mb: 1024,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "".into(),
+            },
+            NodeConfig {
+                name: "n3".into(),
+                available_cpus: vec![0],
+                max_memory_mb: 1024,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "".into(),
+            },
+        ]);
+        let _ = ncm; // suppress unused warning
+
+        let store = new_workload_store();
+        let mock = MockFaultNotifier::arc();
+        let svc = SchedInfoServiceImpl::new(
+            Arc::new(NodeConfigManager::from_nodes(vec![
+                NodeConfig {
+                    name: "n1".into(),
+                    available_cpus: vec![0, 1],
+                    max_memory_mb: 4096,
+                    architecture: "x86_64".into(),
+                    location: "test".into(),
+                    description: "".into(),
+                },
+                NodeConfig {
+                    name: "n2".into(),
+                    available_cpus: vec![0, 1],
+                    max_memory_mb: 4096,
+                    architecture: "x86_64".into(),
+                    location: "test".into(),
+                    description: "".into(),
+                },
+                NodeConfig {
+                    name: "n3".into(),
+                    available_cpus: vec![0, 1],
+                    max_memory_mb: 4096,
+                    architecture: "x86_64".into(),
+                    location: "test".into(),
+                    description: "".into(),
+                },
+            ])),
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+        );
+        let node_svc = NodeServiceImpl::new(
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+            Duration::from_millis(80),
+        );
+
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl3".into(),
+            tasks: vec![
+                task_for("t1", "n1"),
+                task_for("t2", "n2"),
+                task_for("t3", "n3"),
+            ],
+        }))
+        .await
+        .unwrap();
+
+        // n1 and n2 join; n3 never does.
+        let nsvc1 = node_svc.clone();
+        let nsvc2 = node_svc.clone();
+
+        let h1 = tokio::spawn(async move {
+            nsvc1
+                .sync_timer(Request::new(SyncRequest {
+                    node_id: "n1".into(),
+                }))
+                .await
+        });
+        let h2 = tokio::spawn(async move {
+            nsvc2
+                .sync_timer(Request::new(SyncRequest {
+                    node_id: "n2".into(),
+                }))
+                .await
+        });
+
+        let (r1, r2) = tokio::time::timeout(Duration::from_secs(2), async { tokio::join!(h1, h2) })
+            .await
+            .expect("both handlers should complete within 2s");
+
+        let e1 = r1.unwrap().unwrap_err();
+        let e2 = r2.unwrap().unwrap_err();
+
+        assert_eq!(
+            e1.code(),
+            tonic::Code::DeadlineExceeded,
+            "n1 should get DeadlineExceeded"
+        );
+        assert_eq!(
+            e2.code(),
+            tonic::Code::DeadlineExceeded,
+            "n2 should get DeadlineExceeded"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_timer_returns_aborted_when_workload_replaced_while_waiting() {
+        let (svc, node_svc, _) = test_services();
+
+        // Two-node workload: n1 will block because n2 never joins.
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl1".into(),
+            tasks: vec![task_for("t1", "n1"), task_for("t2", "n2")],
+        }))
+        .await
+        .unwrap();
+
+        let nsvc = node_svc.clone();
+        let handle = tokio::spawn(async move {
+            nsvc.sync_timer(Request::new(SyncRequest {
+                node_id: "n1".into(),
+            }))
+            .await
+        });
+
+        // Give n1 time to register and begin awaiting the barrier.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        // Replace the workload — this broadcasts Cancelled to the old barrier.
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl2".into(),
+            tasks: vec![task_for("t3", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("SyncTimer should complete after workload replacement")
+            .expect("spawned task should not panic");
+
+        assert_eq!(result.unwrap_err().code(), tonic::Code::Aborted);
+    }
+
+    // ── ReportDMiss ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn report_d_miss_no_workload_returns_error_status() {
+        let (_, node_svc, _) = test_services();
+        let resp = node_svc
+            .report_d_miss(Request::new(DeadlineMissInfo {
+                node_id: "n1".into(),
+                task_name: "t1".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_ne!(resp.status, 0);
+    }
+
+    #[tokio::test]
+    async fn report_d_miss_known_task_calls_fault_notifier() {
+        let (svc, node_svc, mock) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let resp = node_svc
+            .report_d_miss(Request::new(DeadlineMissInfo {
+                node_id: "n1".into(),
+                task_name: "t1".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.status, 0);
+        let calls = mock.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].workload_id, "wl");
+        assert_eq!(calls[0].node_id, "n1");
+        assert_eq!(calls[0].task_name, "t1");
+    }
+
+    #[tokio::test]
+    async fn report_d_miss_unknown_task_uses_fallback_workload_id_and_still_notifies() {
+        let (svc, node_svc, mock) = test_services();
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl_fallback".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        // Report a miss for a task name that doesn't exist in the schedule.
+        let resp = node_svc
+            .report_d_miss(Request::new(DeadlineMissInfo {
+                node_id: "n1".into(),
+                task_name: "task_that_does_not_exist".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // Should still succeed via the fallback path (uses current workload_id).
+        assert_eq!(resp.status, 0);
+        let calls = mock.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].workload_id, "wl_fallback");
+    }
+
+    #[tokio::test]
+    async fn report_d_miss_notifier_failure_returns_error_status() {
+        // Custom notifier that always fails.
+        struct FailingNotifier;
+        #[tonic::async_trait]
+        impl FaultNotifier for FailingNotifier {
+            async fn notify_fault(&self, _: FaultNotification) -> Result<(), FaultError> {
+                Err(FaultError::RemoteError(-1))
+            }
+        }
+
+        let store = new_workload_store();
+        // Populate the workload via a service that uses a working mock.
+        let mock = MockFaultNotifier::arc();
+        let svc = SchedInfoServiceImpl::new(
+            two_node_config(),
+            Arc::clone(&store),
+            Arc::clone(&mock) as Arc<dyn FaultNotifier>,
+        );
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        // Node service uses the failing notifier.
+        let failing_svc = NodeServiceImpl::new(
+            Arc::clone(&store),
+            Arc::new(FailingNotifier) as Arc<dyn FaultNotifier>,
+            Duration::from_secs(DEFAULT_SYNC_TIMEOUT_SECS),
+        );
+
+        let resp = failing_svc
+            .report_d_miss(Request::new(DeadlineMissInfo {
+                node_id: "n1".into(),
+                task_name: "t1".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_ne!(resp.status, 0);
+        assert!(!resp.error_message.is_empty());
+    }
+}

--- a/timpani_rust/timpani-o/src/grpc/node_service.rs
+++ b/timpani_rust/timpani-o/src/grpc/node_service.rs
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
 //! |---------------|-----------------------------|--------------------------------------|
 //! | `GetSchedInfo`  | `trpc_client_schedinfo`   | Timpani-N pulls its task list        |
 //! | `SyncTimer`     | `trpc_client_sync`        | Barrier — all nodes start together   |
-//! | `ReportDMiss`   | `trpc_client_dmiss`       | Deadline miss forwarded to Piccolo   |
+//! | `ReportDMiss`   | `trpc_client_dmiss`       | Deadline miss forwarded to Pullpiri  |
 //!
 //! # SyncTimer barrier design
 //!
@@ -43,6 +43,10 @@ use crate::proto::schedinfo_v1::{
 use super::{BarrierStatus, WorkloadStore};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Nanoseconds in one second — used to split a nanosecond timestamp into
+/// `(seconds, nanoseconds)` matching `struct timespec`.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
 
 /// Offset added to `now` when computing the barrier start time.
 ///
@@ -94,7 +98,7 @@ fn compute_start_time() -> (i64, i32) {
         .unwrap_or_default()
         .as_nanos() as i64;
     let start_ns = now_ns + SYNC_START_OFFSET_NS;
-    (start_ns / 1_000_000_000, (start_ns % 1_000_000_000) as i32)
+    (start_ns / NANOS_PER_SEC, (start_ns % NANOS_PER_SEC) as i32)
 }
 
 /// Convert an internal `SchedTask` to the proto wire type `ScheduledTask`.
@@ -364,7 +368,7 @@ impl NodeService for NodeServiceImpl {
             }
         };
 
-        // Forward the fault to Piccolo.
+        // Forward the fault to Pullpiri.
         let notification = FaultNotification {
             workload_id,
             node_id,
@@ -373,7 +377,7 @@ impl NodeService for NodeServiceImpl {
         };
 
         if let Err(e) = self.fault_notifier.notify_fault(notification).await {
-            error!(error = %e, "Failed to notify Piccolo of deadline miss");
+            error!(error = %e, "Failed to notify Pullpiri of deadline miss");
             return Ok(Response::new(NodeResponse {
                 status: -1,
                 error_message: format!("fault notification failed: {e}"),

--- a/timpani_rust/timpani-o/src/grpc/schedinfo_service.rs
+++ b/timpani_rust/timpani-o/src/grpc/schedinfo_service.rs
@@ -1,0 +1,346 @@
+/*
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+SPDX-License-Identifier: MIT
+*/
+
+//! `SchedInfoService` gRPC server — receives workloads from Piccolo.
+//!
+//! Implements the `AddSchedInfo` RPC:
+//!   1. Convert proto `TaskInfo` list → internal `Vec<Task>`.
+//!   2. Calculate hyperperiod (LCM of all task periods).
+//!   3. Run `GlobalScheduler` to assign tasks to nodes and CPUs.
+//!   4. Acquire `WorkloadStore` lock briefly, cancel previous workload's
+//!      sync barrier, store the new `WorkloadState`, release lock.
+
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
+
+use crate::config::NodeConfigManager;
+use crate::fault::FaultNotifier;
+use crate::hyperperiod::HyperperiodManager;
+use crate::proto::schedinfo_v1::{
+    sched_info_service_server::SchedInfoService, Response as ProtoResponse, SchedInfo, TaskInfo,
+};
+use crate::scheduler::GlobalScheduler;
+use crate::task::{CpuAffinity, SchedPolicy, Task};
+
+use super::{BarrierStatus, WorkloadState, WorkloadStore};
+
+// ── Service struct ────────────────────────────────────────────────────────────
+
+/// tonic implementation of `SchedInfoService`.
+///
+/// `Clone` is required by tonic (it clones the service for each connection).
+/// All fields are `Arc`-wrapped so cloning is cheap.
+#[derive(Clone)]
+pub struct SchedInfoServiceImpl {
+    scheduler: Arc<GlobalScheduler>,
+    workload_store: WorkloadStore,
+    /// Injected fault notifier — used for future scheduler-error forwarding.
+    /// Not yet called in the port; present so the injection pipeline exists.
+    #[allow(dead_code)]
+    fault_notifier: Arc<dyn FaultNotifier>,
+}
+
+impl SchedInfoServiceImpl {
+    pub fn new(
+        node_config_manager: Arc<NodeConfigManager>,
+        workload_store: WorkloadStore,
+        fault_notifier: Arc<dyn FaultNotifier>,
+    ) -> Self {
+        Self {
+            scheduler: Arc::new(GlobalScheduler::new(node_config_manager)),
+            workload_store,
+            fault_notifier,
+        }
+    }
+}
+
+// ── Proto → Task conversion ───────────────────────────────────────────────────
+
+/// Convert a proto `TaskInfo` into an internal `Task`.
+///
+/// `workload_id` comes from the enclosing `SchedInfo` message; every task in
+/// one RPC call shares the same value.
+fn task_from_proto(t: &TaskInfo, workload_id: &str) -> Task {
+    Task {
+        name: t.name.clone(),
+        workload_id: workload_id.to_owned(),
+        // node_id in the proto is the preferred/required target node.
+        target_node: t.node_id.clone(),
+        policy: SchedPolicy::from_proto_int(t.policy),
+        priority: t.priority,
+        affinity: CpuAffinity::from_proto(t.cpu_affinity),
+        period_us: t.period.max(0) as u64,
+        runtime_us: t.runtime.max(0) as u64,
+        deadline_us: t.deadline.max(0) as u64,
+        release_time_us: t.release_time.max(0) as u32,
+        max_dmiss: t.max_dmiss,
+        memory_mb: 0, // not in proto yet — dormant (D-003)
+        ..Task::default()
+    }
+}
+
+// ── SchedInfoService implementation ──────────────────────────────────────────
+
+#[tonic::async_trait]
+impl SchedInfoService for SchedInfoServiceImpl {
+    async fn add_sched_info(
+        &self,
+        request: Request<SchedInfo>,
+    ) -> Result<Response<ProtoResponse>, Status> {
+        let req = request.into_inner();
+        let workload_id = req.workload_id.clone();
+
+        info!(
+            workload_id = %workload_id,
+            task_count  = req.tasks.len(),
+            "AddSchedInfo received"
+        );
+
+        // Log per-task details at debug level (mirrors C++ TLOG_DEBUG block).
+        for (i, t) in req.tasks.iter().enumerate() {
+            tracing::debug!(
+                idx          = i,
+                name         = %t.name,
+                node_id      = %t.node_id,
+                priority     = t.priority,
+                cpu_affinity = %format!("0x{:016x}", t.cpu_affinity),
+                period_us    = t.period,
+                runtime_us   = t.runtime,
+                deadline_us  = t.deadline,
+                "task"
+            );
+        }
+
+        // ── 1. Convert proto tasks to internal representation ─────────────────
+        let tasks: Vec<Task> = req
+            .tasks
+            .iter()
+            .map(|t| task_from_proto(t, &workload_id))
+            .collect();
+
+        // ── 2. Calculate hyperperiod ──────────────────────────────────────────
+        // Create a fresh HyperperiodManager per call — we only need the result
+        // once and storing it in WorkloadState.  The clone gives us ownership.
+        let hyperperiod_info = {
+            let mut hp_mgr = HyperperiodManager::new();
+            match hp_mgr.calculate_hyperperiod(&workload_id, &tasks) {
+                Ok(info) => info.clone(),
+                Err(e) => {
+                    error!(
+                        workload_id = %workload_id,
+                        error = %e,
+                        "Hyperperiod calculation failed"
+                    );
+                    return Ok(Response::new(ProtoResponse { status: -1 }));
+                }
+            }
+        };
+
+        info!(
+            workload_id    = %workload_id,
+            hyperperiod_ms = hyperperiod_info.hyperperiod_us / 1_000,
+            task_count     = hyperperiod_info.task_count,
+            "Hyperperiod calculated"
+        );
+
+        // ── 3. Run GlobalScheduler ────────────────────────────────────────────
+        let schedule = match self.scheduler.schedule(tasks, "target_node_priority") {
+            Ok(s) => s,
+            Err(e) => {
+                error!(
+                    workload_id = %workload_id,
+                    error = %e,
+                    "GlobalScheduler::schedule() failed"
+                );
+                return Ok(Response::new(ProtoResponse { status: -1 }));
+            }
+        };
+
+        info!(
+            workload_id = %workload_id,
+            node_count  = schedule.len(),
+            "Schedule produced"
+        );
+        for (node, tasks) in &schedule {
+            info!("  node '{node}': {} task(s)", tasks.len());
+        }
+
+        // ── 4. Store workload (brief lock) ────────────────────────────────────
+        {
+            let mut guard = self.workload_store.lock().await;
+
+            if let Some(prev) = guard.as_ref() {
+                warn!(
+                    prev_workload = %prev.workload_id,
+                    new_workload  = %workload_id,
+                    "Replacing existing workload \
+                     (single-workload limitation — see DEVELOPER_NOTES D-016)"
+                );
+                // Wake all SyncTimer handlers waiting on the previous barrier.
+                let _ = prev.barrier_tx.send(BarrierStatus::Cancelled);
+            }
+
+            *guard = Some(WorkloadState::new(
+                workload_id.clone(),
+                schedule,
+                hyperperiod_info,
+            ));
+        } // lock released here
+
+        info!(workload_id = %workload_id, "Workload stored, awaiting node sync");
+        Ok(Response::new(ProtoResponse { status: 0 }))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Request;
+
+    use crate::config::{NodeConfig, NodeConfigManager};
+    use crate::fault::{test_support::MockFaultNotifier, FaultNotifier};
+    use crate::grpc::{new_workload_store, BarrierStatus};
+    use crate::proto::schedinfo_v1::{
+        sched_info_service_server::SchedInfoService, SchedInfo, TaskInfo,
+    };
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn two_node_config() -> Arc<NodeConfigManager> {
+        Arc::new(NodeConfigManager::from_nodes(vec![
+            NodeConfig {
+                name: "n1".into(),
+                available_cpus: vec![0, 1],
+                max_memory_mb: 4096,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "test node 1".into(),
+            },
+            NodeConfig {
+                name: "n2".into(),
+                available_cpus: vec![0, 1],
+                max_memory_mb: 4096,
+                architecture: "x86_64".into(),
+                location: "test".into(),
+                description: "test node 2".into(),
+            },
+        ]))
+    }
+
+    fn task_for(name: &str, node: &str) -> TaskInfo {
+        TaskInfo {
+            name: name.into(),
+            node_id: node.into(),
+            priority: 50,
+            policy: 1,
+            cpu_affinity: 0,
+            period: 10_000,
+            runtime: 1_000,
+            deadline: 10_000,
+            release_time: 0,
+            max_dmiss: 3,
+        }
+    }
+
+    fn make_svc_with_store(store: WorkloadStore) -> SchedInfoServiceImpl {
+        let mock = MockFaultNotifier::arc();
+        SchedInfoServiceImpl::new(two_node_config(), store, mock as Arc<dyn FaultNotifier>)
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_sched_info_two_nodes_returns_ok_status() {
+        let svc = make_svc_with_store(new_workload_store());
+        let si = SchedInfo {
+            workload_id: "wl_ok".into(),
+            tasks: vec![task_for("t1", "n1"), task_for("t2", "n2")],
+        };
+        let resp = svc.add_sched_info(Request::new(si)).await.unwrap();
+        assert_eq!(resp.into_inner().status, 0);
+    }
+
+    #[tokio::test]
+    async fn add_sched_info_empty_tasks_returns_error_status() {
+        let svc = make_svc_with_store(new_workload_store());
+        let resp = svc
+            .add_sched_info(Request::new(SchedInfo {
+                workload_id: "wl_empty".into(),
+                tasks: vec![],
+            }))
+            .await
+            .unwrap();
+        assert_ne!(resp.into_inner().status, 0);
+    }
+
+    #[tokio::test]
+    async fn add_sched_info_unknown_node_returns_error_status() {
+        let svc = make_svc_with_store(new_workload_store());
+        let resp = svc
+            .add_sched_info(Request::new(SchedInfo {
+                workload_id: "wl_bad".into(),
+                tasks: vec![task_for("t1", "node_not_in_config")],
+            }))
+            .await
+            .unwrap();
+        assert_ne!(resp.into_inner().status, 0);
+    }
+
+    #[tokio::test]
+    async fn add_sched_info_stores_workload_in_workload_store() {
+        let store = new_workload_store();
+        let svc = make_svc_with_store(Arc::clone(&store));
+
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl_stored".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let guard = store.lock().await;
+        let ws = guard.as_ref().expect("workload should be in the store");
+        assert_eq!(ws.workload_id, "wl_stored");
+        assert!(ws.active_nodes.contains("n1"));
+    }
+
+    #[tokio::test]
+    async fn add_sched_info_replaces_previous_workload_and_cancels_barrier() {
+        let store = new_workload_store();
+        let svc = make_svc_with_store(Arc::clone(&store));
+
+        // First workload — subscribe to its barrier before replacing
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl_first".into(),
+            tasks: vec![task_for("t1", "n1")],
+        }))
+        .await
+        .unwrap();
+
+        let barrier_rx = {
+            let guard = store.lock().await;
+            guard.as_ref().unwrap().barrier_tx.subscribe()
+        };
+
+        // Replace with second workload
+        svc.add_sched_info(Request::new(SchedInfo {
+            workload_id: "wl_second".into(),
+            tasks: vec![task_for("t2", "n2")],
+        }))
+        .await
+        .unwrap();
+
+        // First barrier should now be Cancelled
+        assert_eq!(*barrier_rx.borrow(), BarrierStatus::Cancelled);
+
+        // Active workload should be the second one
+        let guard = store.lock().await;
+        assert_eq!(guard.as_ref().unwrap().workload_id, "wl_second");
+    }
+}

--- a/timpani_rust/timpani-o/src/grpc/schedinfo_service.rs
+++ b/timpani_rust/timpani-o/src/grpc/schedinfo_service.rs
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
 SPDX-License-Identifier: MIT
 */
 
-//! `SchedInfoService` gRPC server — receives workloads from Piccolo.
+//! `SchedInfoService` gRPC server — receives workloads from Pullpiri.
 //!
 //! Implements the `AddSchedInfo` RPC:
 //!   1. Convert proto `TaskInfo` list → internal `Vec<Task>`.

--- a/timpani_rust/timpani-o/src/lib.rs
+++ b/timpani_rust/timpani-o/src/lib.rs
@@ -13,16 +13,14 @@ SPDX-License-Identifier: MIT
 //! ├── config/         – YAML node configuration
 //! ├── scheduler/      – three scheduling algorithms
 //! ├── hyperperiod/    – LCM / GCD helpers
-//! ├── grpc/           – gRPC server + client wiring  (pending)
-//! └── fault/          – fault reporting to Pullpiri  (pending)
+//! ├── grpc/           – gRPC server + client wiring
+//! └── fault/          – fault reporting to Pullpiri
 //! ```
 
 pub mod config;
+pub mod fault;
+pub mod grpc;
 pub mod hyperperiod;
 pub mod proto;
 pub mod scheduler;
 pub mod task;
-
-// Placeholders – uncommented as each module is implemented
-// pub mod grpc;
-// pub mod fault;

--- a/timpani_rust/timpani-o/src/main.rs
+++ b/timpani_rust/timpani-o/src/main.rs
@@ -37,15 +37,15 @@ use timpani_o::proto::schedinfo_v1::{
     long_about = None,
 )]
 struct Cli {
-    /// Port for the upstream SchedInfoService gRPC server (receives workloads from Piccolo).
+    /// Port for the upstream SchedInfoService gRPC server (receives workloads from Pullpiri).
     #[arg(short = 's', long = "sinfoport", default_value_t = 50052)]
     sinfo_port: u16,
 
-    /// FaultService host address (Piccolo gRPC endpoint).
+    /// FaultService host address (Pullpiri gRPC endpoint).
     #[arg(short = 'f', long = "faulthost", default_value = "localhost")]
     fault_host: String,
 
-    /// Port for the FaultService gRPC client (Piccolo endpoint).
+    /// Port for the FaultService gRPC client (Pullpiri endpoint).
     #[arg(short = 'p', long = "faultport", default_value_t = 50053)]
     fault_port: u16,
 
@@ -138,16 +138,16 @@ async fn main() {
     let node_config_manager = Arc::new(node_config_manager);
     let workload_store = new_workload_store();
 
-    // ── Fault client (lazy — connects to Piccolo on first RPC call) ───────────
-    let piccolo_addr = format!("http://{}:{}", cli.fault_host, cli.fault_port);
-    let fault_notifier = match FaultClient::connect_lazy(piccolo_addr.clone()) {
+    // ── Fault client (lazy — connects to Pullpiri on first RPC call) ──────────
+    let pullpiri_addr = format!("http://{}:{}", cli.fault_host, cli.fault_port);
+    let fault_notifier = match FaultClient::connect_lazy(pullpiri_addr.clone()) {
         Ok(n) => n,
         Err(e) => {
-            error!("Failed to build FaultClient for {piccolo_addr}: {e}");
+            error!("Failed to build FaultClient for {pullpiri_addr}: {e}");
             process::exit(1);
         }
     };
-    info!(addr = %piccolo_addr, "FaultClient ready (lazy connect)");
+    info!(addr = %pullpiri_addr, "FaultClient ready (lazy connect)");
 
     // ── gRPC service instances ────────────────────────────────────────────────
     let sched_info_svc = SchedInfoServiceImpl::new(
@@ -169,7 +169,7 @@ async fn main() {
         .parse()
         .expect("invalid node_port");
 
-    info!(addr = %sinfo_addr, "SchedInfoService starting (upstream — Piccolo)");
+    info!(addr = %sinfo_addr, "SchedInfoService starting (upstream — Pullpiri)");
     info!(addr = %node_addr,  "NodeService starting      (downstream — Timpani-N)");
 
     // ── Graceful shutdown — shared watch channel ──────────────────────────────
@@ -212,16 +212,16 @@ async fn main() {
 
     // ── Optional NotifyFault demo ─────────────────────────────────────────────
     //
-    // Matches C++ NotifyFaultDemo(): sends one synthetic fault to Piccolo after
+    // Matches C++ NotifyFaultDemo(): sends one synthetic fault to Pullpiri after
     // a short startup delay to verify the FaultService connection is reachable.
-    // Useful when you want to confirm the Piccolo side is listening without
+    // Useful when you want to confirm the Pullpiri side is listening without
     // needing a real deadline miss event.
     if cli.notify_fault {
         let notifier = Arc::clone(&fault_notifier);
         tokio::spawn(async move {
             // Give the servers a moment to bind before attempting the outbound call.
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            info!("--notifyfault: sending synthetic fault notification to Piccolo");
+            info!("--notifyfault: sending synthetic fault notification to Pullpiri");
             let result = notifier
                 .notify_fault(FaultNotification {
                     workload_id: "workload_demo".into(),

--- a/timpani_rust/timpani-o/src/main.rs
+++ b/timpani_rust/timpani-o/src/main.rs
@@ -5,11 +5,23 @@ SPDX-License-Identifier: MIT
 
 use std::path::PathBuf;
 use std::process;
+use std::sync::Arc;
 
 use clap::Parser;
+use tonic::transport::Server;
 use tracing::{error, info, warn};
 
 use timpani_o::config::NodeConfigManager;
+use timpani_o::fault::{FaultClient, FaultNotification};
+use timpani_o::grpc::{
+    new_workload_store,
+    node_service::{NodeServiceImpl, DEFAULT_SYNC_TIMEOUT_SECS},
+    schedinfo_service::SchedInfoServiceImpl,
+};
+use timpani_o::proto::schedinfo_v1::{
+    node_service_server::NodeServiceServer, sched_info_service_server::SchedInfoServiceServer,
+    FaultType,
+};
 
 // ── CLI argument definition ───────────────────────────────────────────────────
 
@@ -25,15 +37,15 @@ use timpani_o::config::NodeConfigManager;
     long_about = None,
 )]
 struct Cli {
-    /// Port for the upstream SchedInfoService gRPC server (receives workloads from Pullpiri).
+    /// Port for the upstream SchedInfoService gRPC server (receives workloads from Piccolo).
     #[arg(short = 's', long = "sinfoport", default_value_t = 50052)]
     sinfo_port: u16,
 
-    /// FaultService host address (Pullpiri gRPC endpoint).
+    /// FaultService host address (Piccolo gRPC endpoint).
     #[arg(short = 'f', long = "faulthost", default_value = "localhost")]
     fault_host: String,
 
-    /// Port for the FaultService gRPC client (Pullpiri endpoint).
+    /// Port for the FaultService gRPC client (Piccolo endpoint).
     #[arg(short = 'p', long = "faultport", default_value_t = 50053)]
     fault_port: u16,
 
@@ -44,6 +56,14 @@ struct Cli {
     /// Enable the NotifyFault demo (sends one fault notification then clears).
     #[arg(short = 'n', long = "notifyfault", default_value_t = false)]
     notify_fault: bool,
+
+    /// Timeout (seconds) for the SyncTimer barrier.
+    ///
+    /// If not all active nodes call SyncTimer within this window, the barrier
+    /// is cancelled and all waiting nodes receive DEADLINE_EXCEEDED.  Set to 0
+    /// to use the built-in default of 30 seconds.
+    #[arg(short = 't', long = "sync-timeout-secs", default_value_t = DEFAULT_SYNC_TIMEOUT_SECS)]
+    sync_timeout_secs: u64,
 
     /// Path to the YAML node configuration file.
     #[arg(short = 'c', long = "nodeconfig")]
@@ -69,12 +89,13 @@ async fn main() {
     let cli = Cli::parse();
 
     info!(
-        sinfo_port   = cli.sinfo_port,
-        fault_host   = %cli.fault_host,
-        fault_port   = cli.fault_port,
-        node_port    = cli.node_port,
-        notify_fault = cli.notify_fault,
-        node_config  = ?cli.node_config,
+        sinfo_port        = cli.sinfo_port,
+        fault_host        = %cli.fault_host,
+        fault_port        = cli.fault_port,
+        node_port         = cli.node_port,
+        notify_fault      = cli.notify_fault,
+        sync_timeout_secs = cli.sync_timeout_secs,
+        node_config       = ?cli.node_config,
         "Configuration"
     );
 
@@ -110,6 +131,126 @@ async fn main() {
                 arch = node.architecture,
                 loc = node.location,
             );
+        }
+    }
+
+    // ── Shared state ──────────────────────────────────────────────────────────
+    let node_config_manager = Arc::new(node_config_manager);
+    let workload_store = new_workload_store();
+
+    // ── Fault client (lazy — connects to Piccolo on first RPC call) ───────────
+    let piccolo_addr = format!("http://{}:{}", cli.fault_host, cli.fault_port);
+    let fault_notifier = match FaultClient::connect_lazy(piccolo_addr.clone()) {
+        Ok(n) => n,
+        Err(e) => {
+            error!("Failed to build FaultClient for {piccolo_addr}: {e}");
+            process::exit(1);
+        }
+    };
+    info!(addr = %piccolo_addr, "FaultClient ready (lazy connect)");
+
+    // ── gRPC service instances ────────────────────────────────────────────────
+    let sched_info_svc = SchedInfoServiceImpl::new(
+        Arc::clone(&node_config_manager),
+        Arc::clone(&workload_store),
+        Arc::clone(&fault_notifier),
+    );
+    let node_svc = NodeServiceImpl::new(
+        Arc::clone(&workload_store),
+        Arc::clone(&fault_notifier),
+        std::time::Duration::from_secs(cli.sync_timeout_secs),
+    );
+
+    // ── Server addresses ──────────────────────────────────────────────────────
+    let sinfo_addr = format!("0.0.0.0:{}", cli.sinfo_port)
+        .parse()
+        .expect("invalid sinfo_port");
+    let node_addr = format!("0.0.0.0:{}", cli.node_port)
+        .parse()
+        .expect("invalid node_port");
+
+    info!(addr = %sinfo_addr, "SchedInfoService starting (upstream — Piccolo)");
+    info!(addr = %node_addr,  "NodeService starting      (downstream — Timpani-N)");
+
+    // ── Graceful shutdown — shared watch channel ──────────────────────────────
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let mut shutdown_rx_node = shutdown_rx.clone();
+
+    // Signal handler task: watches for Ctrl-C or SIGTERM.
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut sigterm =
+                signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = sigterm.recv()          => {}
+            }
+        }
+        #[cfg(not(unix))]
+        tokio::signal::ctrl_c().await.ok();
+
+        info!("Shutdown signal received — stopping servers");
+        let _ = shutdown_tx.send(true);
+    });
+
+    // Shutdown futures: each server gets its own receiver clone.
+    let sinfo_shutdown = {
+        let mut rx = shutdown_rx.clone();
+        async move {
+            while !*rx.borrow() {
+                rx.changed().await.ok();
+            }
+        }
+    };
+    let node_shutdown = async move {
+        while !*shutdown_rx_node.borrow() {
+            shutdown_rx_node.changed().await.ok();
+        }
+    };
+
+    // ── Optional NotifyFault demo ─────────────────────────────────────────────
+    //
+    // Matches C++ NotifyFaultDemo(): sends one synthetic fault to Piccolo after
+    // a short startup delay to verify the FaultService connection is reachable.
+    // Useful when you want to confirm the Piccolo side is listening without
+    // needing a real deadline miss event.
+    if cli.notify_fault {
+        let notifier = Arc::clone(&fault_notifier);
+        tokio::spawn(async move {
+            // Give the servers a moment to bind before attempting the outbound call.
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            info!("--notifyfault: sending synthetic fault notification to Piccolo");
+            let result = notifier
+                .notify_fault(FaultNotification {
+                    workload_id: "workload_demo".into(),
+                    node_id: "node_demo".into(),
+                    task_name: "task_demo".into(),
+                    fault_type: FaultType::Dmiss,
+                })
+                .await;
+            match result {
+                Ok(()) => info!("--notifyfault: synthetic fault delivered successfully"),
+                Err(e) => warn!("--notifyfault: fault notification failed: {e}"),
+            }
+        });
+    }
+
+    // ── Start both servers concurrently ──────────────────────────────────────
+    let sinfo_server = Server::builder()
+        .add_service(SchedInfoServiceServer::new(sched_info_svc))
+        .serve_with_shutdown(sinfo_addr, sinfo_shutdown);
+
+    let node_server = Server::builder()
+        .add_service(NodeServiceServer::new(node_svc))
+        .serve_with_shutdown(node_addr, node_shutdown);
+
+    match tokio::try_join!(sinfo_server, node_server) {
+        Ok(_) => info!("Servers stopped cleanly"),
+        Err(e) => {
+            error!("Server error: {e}");
+            process::exit(1);
         }
     }
 }

--- a/timpani_rust/timpani-o/src/scheduler/error.rs
+++ b/timpani_rust/timpani-o/src/scheduler/error.rs
@@ -168,3 +168,111 @@ pub enum SchedulerError {
     #[error("no schedulable node found for task '{task}'")]
     NoSchedulableNode { task: String },
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── AdmissionReason Display ───────────────────────────────────────────────
+
+    #[test]
+    fn admission_node_not_found_display() {
+        let r = AdmissionReason::NodeNotFound {
+            node: "node99".into(),
+        };
+        assert!(r.to_string().contains("node99"));
+    }
+
+    #[test]
+    fn admission_insufficient_memory_display() {
+        let r = AdmissionReason::InsufficientMemory {
+            required_mb: 8192,
+            available_mb: 4096,
+        };
+        let s = r.to_string();
+        assert!(s.contains("8192"));
+        assert!(s.contains("4096"));
+    }
+
+    #[test]
+    fn admission_cpu_affinity_unavailable_display() {
+        let r = AdmissionReason::CpuAffinityUnavailable { requested_cpu: 7 };
+        assert!(r.to_string().contains('7'));
+    }
+
+    #[test]
+    fn admission_cpu_utilization_exceeded_display() {
+        let r = AdmissionReason::CpuUtilizationExceeded {
+            cpu: 2,
+            current: 0.85,
+            added: 0.10,
+            threshold: 0.90,
+        };
+        let s = r.to_string();
+        assert!(s.contains("CPU 2"));
+        assert!(s.contains("90")); // threshold percentage
+    }
+
+    #[test]
+    fn admission_no_available_cpu_display() {
+        assert!(!AdmissionReason::NoAvailableCpu.to_string().is_empty());
+    }
+
+    // ── SchedulerError Display ────────────────────────────────────────────────
+
+    #[test]
+    fn error_no_tasks_display() {
+        assert!(SchedulerError::NoTasks.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn error_config_not_loaded_display() {
+        assert!(SchedulerError::ConfigNotLoaded
+            .to_string()
+            .contains("configuration"));
+    }
+
+    #[test]
+    fn error_unknown_algorithm_display() {
+        let e = SchedulerError::UnknownAlgorithm("my_algo".into());
+        assert!(e.to_string().contains("my_algo"));
+    }
+
+    #[test]
+    fn error_missing_workload_id_display() {
+        let e = SchedulerError::MissingWorkloadId {
+            task: "task1".into(),
+        };
+        assert!(e.to_string().contains("task1"));
+    }
+
+    #[test]
+    fn error_missing_target_node_display() {
+        let e = SchedulerError::MissingTargetNode {
+            task: "task2".into(),
+        };
+        assert!(e.to_string().contains("task2"));
+    }
+
+    #[test]
+    fn error_admission_rejected_display() {
+        let e = SchedulerError::AdmissionRejected {
+            task: "task3".into(),
+            node: "node01".into(),
+            reason: AdmissionReason::NoAvailableCpu,
+        };
+        let s = e.to_string();
+        assert!(s.contains("task3"));
+        assert!(s.contains("node01"));
+    }
+
+    #[test]
+    fn error_no_schedulable_node_display() {
+        let e = SchedulerError::NoSchedulableNode {
+            task: "taskX".into(),
+        };
+        assert!(e.to_string().contains("taskX"));
+    }
+}


### PR DESCRIPTION
## PR Description

Implements the full gRPC connectivity layer for Timpani-O (Rust), covering both the upstream Piccolo interface and the downstream Timpani-N node interface.

**Upstream (Piccolo) — #8**
- `SchedInfoService` gRPC server: receives workload schedules from Pullpiri via `AddSchedInfo`; stores them in a shared `WorkloadStore` (tokio `Mutex`) and broadcasts barrier resets on workload replacement
- `FaultClient`: lazily-connected gRPC client that forwards deadline-miss notifications to Pullpiri; injectable via `FaultNotifier` trait for testability

**Downstream (Nodes) — #9**
- `proto/node_service.proto`: defines `NodeService` with `GetSchedInfo`, `SyncTimer`, and `ReportDMiss` RPCs
- `NodeServiceImpl`: serves Timpani-N nodes; `SyncTimer` uses a `tokio::sync::watch` barrier so all nodes in a workload receive an identical `CLOCK_REALTIME` start timestamp simultaneously
- Configurable sync timeout (`--sync-timeout-secs`, default 30 s) via `BarrierStatus::TimedOut`; waiting handlers return `Status::DEADLINE_EXCEEDED` on expiry

**End-to-End Testing — #10**
- `test-tools/` workspace crate (non-production):
  - `piccolo-sim`: sends `AddSchedInfo` to Timpani-O and hosts a `FaultService` to receive notifications
  - `node-sim`: simulates N Timpani-N nodes concurrently, fires the sync barrier, and optionally sends `ReportDMiss`
  - `workloads/example_workload.yaml`: 6-task / 3-node example workload

**Runtime & quality**
- `main.rs` rewritten: two concurrent gRPC servers with graceful `Ctrl-C` / `SIGTERM` shutdown via `tokio::sync::watch`
- `fmt` + `clippy` + `cargo deny` all clean
- 119 unit tests, 0 failures; library coverage 88.32% (484/548 lines)

## Related Issue

Closes #3
Closes #8
Closes #9
Closes #10
Closes #45 
Closes #46 
Closes #47 
Closes #48 