### PR TITLE
chore: Add libbpf submodule and update timpani_rust README

### DIFF
--- a/timpani_rust/README.md
+++ b/timpani_rust/README.md
@@ -5,14 +5,15 @@
 
 # TIMPANI Rust
 
-Rust port of the **TIMPANI-O** global scheduler.  
-The crate mirrors the C++ implementation in [`timpani-o/`](../timpani-o) and exposes the same scheduling algorithms over gRPC.
+Rust ports of the TIMPANI global scheduler and node executor.
+The crates mirror the C++ implementation in [`timpani-o/`](../timpani-o) and the C implementation in [`timpani-n/`](../timpani-n).
 
 ## Crates
 
 | Crate | Description |
 |-------|-------------|
 | `timpani-o` | Global scheduler — task admission, hyperperiod calculation, gRPC service |
+| `timpani-n` | Node executor — executes scheduled tasks on individual nodes |
 
 ## Prerequisites
 
@@ -58,5 +59,5 @@ just setup     # install the pre-push git hook
 
 ## Configuration
 
-The scheduler reads a YAML file describing the available nodes and their CPUs.  
+The scheduler reads a YAML file describing the available nodes and their CPUs.
 See [`timpani-o/examples/node_configurations.yaml`](../timpani-o/examples/node_configurations.yaml) for an example.


### PR DESCRIPTION
## 📝 PR Description
This PR adds the libbpf submodule to the repository and updates the timpani_rust README to include information about the timpani-n crate.

## 🔗 Related Issue
 #11

## 🧪 Test Method
- Initialize the libbpf submodule with `git submodule update --init --recursive`.
- Verify the timpani_rust README displays the timpani-n crate details correctly.
- Run any existing build and test scripts to ensure no regressions.

## 📸 Screenshots
No UI changes.

## ✅ Checklist
- [x] Code conventions are followed
- [ ] Tests are added/modified
- [x] Documentation is updated (if necessary)