### PR TITLE
Implement early initialization of CPU affinity and real-time scheduling policy/priority for the timpani-n daemon process

### DIFF
--- a/timpani_rust/timpani-n/src/context/mod.rs
+++ b/timpani_rust/timpani-n/src/context/mod.rs
@@ -5,6 +5,9 @@
 
 use crate::config::Config;
 use crate::grpc::NodeClient;
+use crate::sched::{set_affinity, set_schedattr, SchedPolicy};
+use nix::unistd::Pid;
+use tracing::{info, warn};
 
 /// Scheduling information received from Timpani-O at startup via GetSchedInfo.
 ///
@@ -95,16 +98,45 @@ impl Context {
         }
     }
 
-    /// Initialize the context (placeholder for future initialization logic)
+    /// Initialize the context
+    ///
+    /// This applies system-level configuration (affinity, scheduling policy)
+    /// to the current process. Future work includes BPF setup, task list
+    /// initialization, and Apex.OS monitor integration.
     pub fn initialize(&mut self) -> crate::error::TimpaniResult<()> {
-        // TODO: Add initialization logic as we port more modules:
-        // - setup_signal_handlers
-        // - set_affinity
-        // - set_schedattr
+        let pid = Pid::from_raw(std::process::id() as i32);
+
+        // Apply CPU affinity if specified (cpu >= 0 means pin to specific CPU)
+        if self.config.cpu >= 0 {
+            info!("Setting CPU affinity to CPU {}", self.config.cpu);
+            set_affinity(pid, self.config.cpu as u32)?;
+        } else {
+            warn!("CPU affinity not set (cpu=-1 means no pinning)");
+        }
+
+        // Apply scheduling policy and priority if specified (prio >= 0)
+        if self.config.prio >= 0 {
+            // Determine policy based on priority:
+            // - prio 1-99: SCHED_FIFO (real-time)
+            // - prio 0: SCHED_OTHER (normal)
+            let policy = if self.config.prio > 0 && self.config.prio <= 99 {
+                SchedPolicy::Fifo
+            } else {
+                SchedPolicy::Normal
+            };
+
+            info!(
+                "Setting scheduling policy to {:?} with priority {}",
+                policy, self.config.prio
+            );
+            set_schedattr(pid, self.config.prio as u32, policy)?;
+        } else {
+            warn!("Scheduling policy not modified (prio=-1 means default)");
+        }
+
+        // TODO: Add additional initialization logic as we port more modules:
         // - calibrate_bpf_time_offset
-        // - init_trpc
-        // - init_task_list or init_apex_list
-        // - apex_monitor_init
+        // - init_task_list
 
         Ok(())
     }
@@ -151,6 +183,53 @@ mod tests {
     }
 
     #[test]
+    fn test_context_initialization_with_defaults() {
+        // Default config has cpu=0, prio=0 which should skip affinity/sched setup
+        let config = Config::default();
+        let mut ctx = Context::new(config);
+        // Should succeed even without setting affinity (cpu=0 means skip)
+        assert!(ctx.initialize().is_ok());
+    }
+
+    #[test]
+    #[ignore] // Requires CAP_SYS_NICE for RT priority
+    fn test_context_initialization_with_rt_priority() {
+        let config = Config {
+            cpu: 0, // Skip affinity
+            prio: 50,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(config);
+        // May fail without privileges
+        let _ = ctx.initialize();
+    }
+
+    #[test]
+    fn test_context_initialization_with_cpu_affinity() {
+        let config = Config {
+            cpu: 1,  // Pin to CPU 1
+            prio: 0, // Skip scheduling
+            ..Default::default()
+        };
+        let mut ctx = Context::new(config);
+        // May fail without privileges but should attempt it
+        let _ = ctx.initialize();
+    }
+
+    #[test]
+    #[ignore] // Requires CAP_SYS_NICE
+    fn test_context_full_initialization() {
+        let config = Config {
+            cpu: 1,
+            prio: 85,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(config);
+        // Will likely fail without privileges
+        let _ = ctx.initialize();
+    }
+
+    #[test]
     fn test_comm_state_default() {
         let comm = CommState::default();
         // Just ensure it constructs without issues
@@ -172,7 +251,13 @@ mod tests {
         config.node_id = crate::config::test_values::TEST_NODE_ID_SHORT.to_string();
 
         let mut ctx = Context::new(config);
-        assert!(ctx.initialize().is_ok());
+        // May fail without CAP_SYS_NICE permission, but shouldn't panic
+        let result = ctx.initialize();
+        match result {
+            Ok(_) => {}                                       // Success with privileges
+            Err(crate::error::TimpaniError::Permission) => {} // Expected without privileges
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
         ctx.cleanup();
     }
 }

--- a/timpani_rust/timpani-n/src/lib.rs
+++ b/timpani_rust/timpani-n/src/lib.rs
@@ -61,10 +61,10 @@ pub fn run(_ctx: &mut Context) -> TimpaniResult<()> {
 ///
 /// Sequence:
 ///   1. Signal handlers   → CancellationToken
-///   2. Connect to Timpani-O (with retry)
-///   3. GetSchedInfo       → populate ctx.runtime.sched_info
-///   4. SyncTimer          → populate ctx.runtime.sync_start   (if enable_sync)
-///   5. Initialize context (sched/BPF setup — future work)
+///   2. Initialize context (set CPU affinity, RT priority)
+///   3. Connect to Timpani-O (with retry)
+///   4. GetSchedInfo       → populate ctx.runtime.sched_info
+///   5. SyncTimer          → populate ctx.runtime.sync_start   (if enable_sync)
 ///   6. RT wait loop       → waits for SIGINT/SIGTERM; timer loop fills this later
 pub async fn run_app(config: Config) -> TimpaniResult<()> {
     config.log_config();
@@ -72,23 +72,30 @@ pub async fn run_app(config: Config) -> TimpaniResult<()> {
     // 1. Install signal handlers before any async ops so cancellation is live.
     let cancel = signal::setup_shutdown_handlers()?;
 
-    // 2. Connect to Timpani-O.
-    let addr = format!("http://{}:{}", config.addr, config.port);
-    info!(addr = %addr, "Connecting to Timpani-O");
-    let mut client = grpc::NodeClient::connect(&addr, config.max_retries, cancel.clone()).await?;
+    // 2. Initialize context and apply CPU affinity + RT scheduling policy EARLY.
+    //    This must happen before network operations to ensure the process runs
+    //    on the correct CPU with the correct priority.
+    let mut ctx = Context::new(config.clone());
+    ctx.initialize()?;
 
-    // 3. GetSchedInfo — retry until a workload is available or we give up.
+    // 3. Connect to Timpani-O.
+    let addr = format!("http://{}:{}", ctx.config.addr, ctx.config.port);
+    info!(addr = %addr, "Connecting to Timpani-O");
+    let mut client =
+        grpc::NodeClient::connect(&addr, ctx.config.max_retries, cancel.clone()).await?;
+
+    // 4. GetSchedInfo — retry until a workload is available or we give up.
     //    NOT_FOUND means Timpani-O is alive but no workload has been submitted
     //    yet.  This is expected and mirrors the C init_trpc() retry loop.
     let sched_resp = {
         let mut attempt = 0u32;
         loop {
-            match client.get_sched_info(&config.node_id).await {
+            match client.get_sched_info(&ctx.config.node_id).await {
                 Ok(resp) => break resp,
                 Err(TimpaniError::NotReady) => {
-                    if attempt >= config.max_retries {
+                    if attempt >= ctx.config.max_retries {
                         error!(
-                            attempts = config.max_retries + 1,
+                            attempts = ctx.config.max_retries + 1,
                             "No workload scheduled after max retries — giving up"
                         );
                         return Err(TimpaniError::Network);
@@ -96,7 +103,7 @@ pub async fn run_app(config: Config) -> TimpaniResult<()> {
                     attempt += 1;
                     info!(
                         attempt,
-                        max = config.max_retries + 1,
+                        max = ctx.config.max_retries + 1,
                         "No workload scheduled yet — retrying in 1s"
                     );
                     tokio::select! {
@@ -137,10 +144,10 @@ pub async fn run_app(config: Config) -> TimpaniResult<()> {
         task_count,
     };
 
-    // 4. SyncTimer — barrier across all active nodes (skipped if enable_sync=false).
-    let sync_start = if config.enable_sync {
+    // 5. SyncTimer — barrier across all active nodes (skipped if enable_sync=false).
+    let sync_start = if ctx.config.enable_sync {
         info!("SyncTimer: waiting for all nodes in workload to check in");
-        let sync_resp = client.sync_timer(&config.node_id).await?;
+        let sync_resp = client.sync_timer(&ctx.config.node_id).await?;
         if !sync_resp.ack {
             error!("SyncTimer returned ack=false — barrier failed or timed out");
             return Err(TimpaniError::Network);
@@ -158,14 +165,12 @@ pub async fn run_app(config: Config) -> TimpaniResult<()> {
         None
     };
 
-    // 5. Populate context and run any sync initialization (BPF, sched attrs — future).
-    let mut ctx = Context::new(config);
+    // 6. Populate runtime state with schedule and sync information.
     ctx.runtime.sched_info = Some(sched_info);
     ctx.runtime.sync_start = sync_start;
     ctx.comm.node_client = Some(client);
-    ctx.initialize()?;
 
-    // 6. RT wait loop.  The timer/task module will replace this with the
+    // 7. RT wait loop.  The timer/task module will replace this with the
     //    real deadline-driven loop; ReportDMiss will be called from there.
     info!("Startup complete — waiting for shutdown signal (RT loop not yet implemented)");
     cancel.cancelled().await;
@@ -269,7 +274,7 @@ mod tests {
     fn test_run_and_initialize_combinations() {
         // Test various initialization and run combinations
         let configs = vec![
-            Config::default(),
+            Config::default(), // cpu=-1, prio=-1 (should always work)
             Config {
                 cpu: config::test_values::TEST_CPU_ONE,
                 ..Default::default()
@@ -287,8 +292,14 @@ mod tests {
         ];
 
         for config in configs {
-            let mut ctx = Context::new(config);
-            assert!(initialize(&mut ctx).is_ok());
+            let mut ctx = Context::new(config.clone());
+            // Initialize may fail due to permissions (CAP_SYS_NICE), accept that
+            let init_result = initialize(&mut ctx);
+            match init_result {
+                Ok(_) => {}                                // Success with privileges
+                Err(error::TimpaniError::Permission) => {} // Expected without privileges
+                Err(e) => panic!("Unexpected error for config {:?}: {:?}", config, e),
+            }
             assert!(run(&mut ctx).is_ok());
             ctx.cleanup();
         }


### PR DESCRIPTION
## 📝 Task Description
Implement early initialization of CPU affinity and real-time scheduling policy/priority for the timpani-n daemon process. The configuration must be applied immediately after signal handler setup and before network operations to ensure the process runs on the correct CPU core with the correct real-time priority throughout its lifecycle.

**Changes implemented:**
- Move `Context::initialize()` to run before gRPC connection attempts
- Add CPU affinity configuration using `sched_setaffinity()`
- Add RT scheduling policy (SCHED_FIFO) and priority configuration using `sched_setscheduler()`
- Add appropriate logging for initialization steps
- Add error handling for permission denied scenarios

## 📋 Checklist
- [x] Import `set_affinity`, `set_schedattr`, and `SchedPolicy` in context module
- [x] Implement `Context::initialize()` method to apply CPU affinity and scheduling attributes
- [x] Move `ctx.initialize()` call before network operations in `run_app()`
- [x] Handle type conversion between `i32` config values and `u32` function parameters
- [x] Add logging for affinity and scheduling configuration steps
- [x] Handle permission errors gracefully when CAP_SYS_NICE is not available
- [x] Update startup sequence documentation in code comments
- [x] Test CPU affinity setting without sudo privileges
- [x] Test RT scheduling policy setting with sudo privileges
- [x] Verify settings using `taskset -cp <PID>` and `chrt -p <PID>`
- [x] Add unit tests for context initialization with various configurations
- [x] Build and verify no compilation errors

## 🔗 Related Requirement
closes #73 

## 📐 Implementation Guidelines

**Files modified:**
- `timpani_rust/timpani-n/src/context/mod.rs`: Added initialization logic for CPU affinity and RT scheduling
- `timpani_rust/timpani-n/src/lib.rs`: Moved context initialization before network operations

**Key implementation details:**
1. **CPU Affinity**: Applied when `config.cpu >= 0` using `set_affinity(pid, cpu as u32)`
2. **RT Scheduling**: Applied when `config.prio >= 0`:
   - Priority 1-99: Uses `SCHED_FIFO` (real-time)
   - Priority 0: Uses `SCHED_OTHER` (normal)


## 🧪 Testing Method

### Manual Testing

**Test 1: CPU Affinity (no sudo required)**
```bash

 -c, --cpu <CPU_NUM>          CPU affinity for timetrigger
  -P, --prio <PRIO>            RT priority (1~99) for timetrigger
  -p, --port <PORT>            Port to connect to [default: 7777]
  -n, --node-id <NODE_ID>      Node ID [default: 1]
  -l, --log-level <LEVEL>      Log level (0=silent, 1=error, 2=warning, 3=info, 4=debug, 5=verbose) [default: 3]
  -s, --enable-sync            Enable timer synchronization across multiple nodes
  -g, --enable-plot            Enable saving plot data file by using BPF (<node id>.gpdata)
  -a, --enable-apex            Enable Apex.OS test mode which works without TT schedule info
      --max-retries <RETRIES>  Maximum connection retry attempts to Timpani-O (one attempt per second). Default 300 = 5 minutes — matches C TT_MAX_CONNECTION_RETRIES [default: 300]
  -h, --help                   Print help


cd timpani_rust/timpani-n
cargo run -- -c 2 -p 50054 127.0.0.1 &
PID=$(pgrep -f "target/debug/timpani-n")
taskset -cp $PID
# Expected: pid X's current affinity list: 2
kill -SIGTERM $PID
```

**Test 2: RT Scheduling Policy (requires sudo)**
```bash
cd timpani_rust/timpani-n
sudo cargo run -- -c 2 -P 85 -p 50054 127.0.0.1 &
PID=$(pgrep -f "target/debug/timpani-n")

# Check CPU affinity
taskset -cp $PID
# Expected: pid X's current affinity list: 2

# Check scheduling policy and priority
chrt -p $PID
# Expected: 
#   pid X's current scheduling policy: SCHED_FIFO
#   pid X's current scheduling priority: 85

# Alternative check with ps
ps -o pid,comm,policy,rtprio,psr,cls -p $PID
# Expected: policy=FF, rtprio=85, psr=2

sudo kill -SIGTERM $PID
```
<img width="1821" height="459" alt="image" src="https://github.com/user-attachments/assets/d9a6d4f9-89cd-47ff-96fe-421e579663ab" />

<img width="1253" height="181" alt="image" src="https://github.com/user-attachments/assets/009baf4b-923c-4663-ab19-6635a8692ba4" />


### Unit Testing
```bash
cd timpani_rust/timpani-n
cargo test context::tests
cargo test lib::tests
```


### Verification Checklist
- [x] Log output shows "Setting CPU affinity to CPU X"
- [x] Log output shows "Set CPU affinity for PID Y to CPU X"
- [x] `taskset -cp <PID>` confirms correct CPU
- [x] Log output shows "Setting scheduling policy to Fifo with priority Z"
- [x] `chrt -p <PID>` confirms SCHED_FIFO and correct priority (when run with sudo)
- [x] Permission errors are handled gracefully without crashing
- [x] All unit tests pass
- [x] Process runs correctly with and without sudo


