### PR TITLE
[BUG] Fix cargo-deny advisory failure: bump anyhow to 1.0.103

### DIFF
--- a/timpani_rust/Cargo.lock
+++ b/timpani_rust/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-stream"


### PR DESCRIPTION

## 📝 PR Description
`cargo deny check` was failing the `advisories` check because
`Cargo.lock` pinned `anyhow` to `1.0.102`, which is flagged by
[RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190):
an unsoundness in `Error::downcast_mut()` that causes undefined
behavior when a shared reference ends up in the resulting mutable
borrow chain (e.g. after calling `Error::context`).

Fixed by running `cargo update -p anyhow`, bumping `1.0.102` → `1.0.103`
(the version containing the upstream fix), within the existing
`anyhow = "1"` constraint in `Cargo.toml` — no manifest changes needed.

`cargo deny check` now reports:

advisories ok, bans ok, licenses ok, sources ok




## 🧪 Test Method
- Ran `scripts/deny_check.sh` before the fix — reproduced the failure
  (`advisories FAILED`, unsound advisory `RUSTSEC-2026-0190` on
  `anyhow v1.0.102`).
- Ran `cargo update -p anyhow` in `timpani_rust/`, confirmed only
  `Cargo.lock` changed (`anyhow 1.0.102 -> 1.0.103`), no `Cargo.toml`
  edits required.
- Re-ran `scripts/deny_check.sh` — confirmed it now passes clean
  (`advisories ok, bans ok, licenses ok, sources ok`).


## ✅ Checklist
- [x] Code conventions are followed
- [x] Tests are added/modified (verified via `scripts/deny_check.sh`
      re-run; no source code changed)
- [x] Documentation is updated (not applicable — dependency-only fix)